### PR TITLE
24 predefined collections

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -30,6 +30,7 @@ return PhpCsFixer\Config::create()
     'no_unused_imports' => true,
     'no_whitespace_in_blank_line' => true,
     'normalize_index_brace' => true,
+    'operator_linebreak' => true,
     'ordered_imports' => true,
     'phpdoc_add_missing_param_annotation' => true,
     'phpdoc_annotation_without_dot' => true,

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -50,4 +50,5 @@ return PhpCsFixer\Config::create()
     'trim_array_spaces' => true,
     'void_return' => true,
     'php_unit_method_casing' => ['case' => 'snake_case'],
+    'php_unit_strict' => true,
   ]);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -49,4 +49,5 @@ return PhpCsFixer\Config::create()
     'trailing_comma_in_multiline_array' => true,
     'trim_array_spaces' => true,
     'void_return' => true,
+    'php_unit_method_casing' => ['case' => 'snake_case'],
   ]);

--- a/example/index.php
+++ b/example/index.php
@@ -33,7 +33,7 @@ final class Article
     }
 }
 
-final class TypedArrayArticles extends AbstractTypedArray
+final class ImmutableArticleList extends AbstractTypedArray
 {
     protected function typeToEnforce(): string
     {
@@ -51,16 +51,19 @@ final class TypedArrayArticles extends AbstractTypedArray
     }
 }
 
-function renderArticles(TypedArrayArticles $articles): void
+function renderArticles(ImmutableArticleList $articles): void
 {
     foreach ($articles as $article) {
         echo $article . PHP_EOL;
     }
 }
 
-$articles = new TypedArrayArticles([
+$articles = new ImmutableArticleList([
     new Article(1, 'article-1'),
     new Article(2, 'article-2'),
 ]);
 
 renderArticles($articles);
+
+//The list is immutable, this will thrown an exception!
+//$articles[] = new Article(3, 'article-3');

--- a/src/AbstractTypedArray.php
+++ b/src/AbstractTypedArray.php
@@ -112,8 +112,8 @@ abstract class AbstractTypedArray extends ArrayObject
     private function guardChildTypeToEnforce(): void
     {
         if (
-            !$this->checkForValidClass() &&
-            !$this->checkForScalar()
+            !$this->checkForValidClass()
+            && !$this->checkForScalar()
         ) {
             throw InvalidSetupException::forEnforceType($this->typeToEnforce());
         }
@@ -171,8 +171,8 @@ abstract class AbstractTypedArray extends ArrayObject
     private function guardInstanceList(array $input): void
     {
         if (
-            $this->collectionType() === self::COLLECTION_TYPE_LIST &&
-            array_values($input) !== $input
+            $this->collectionType() === self::COLLECTION_TYPE_LIST
+            && array_values($input) !== $input
         ) {
             throw ListException::keysNotAllowed();
         }
@@ -184,9 +184,9 @@ abstract class AbstractTypedArray extends ArrayObject
     private function guardInstanceMap(array $input): void
     {
         if (
-            !empty($input) &&
-            $this->collectionType() === self::COLLECTION_TYPE_MAP &&
-            array_values($input) === $input
+            !empty($input)
+            && $this->collectionType() === self::COLLECTION_TYPE_MAP
+            && array_values($input) === $input
         ) {
             throw MapException::keysRequired();
         }

--- a/src/AbstractTypedArray.php
+++ b/src/AbstractTypedArray.php
@@ -184,6 +184,7 @@ abstract class AbstractTypedArray extends ArrayObject
     private function guardInstanceMap(array $input): void
     {
         if (
+            !empty($input) &&
             $this->collectionType() === self::COLLECTION_TYPE_MAP &&
             array_values($input) === $input
         ) {

--- a/src/Scalars/ImmutableBooleanArray.php
+++ b/src/Scalars/ImmutableBooleanArray.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArrays\Scalars;
+
+use TypedArrays\AbstractTypedArray;
+
+final class ImmutableBooleanArray extends AbstractTypedArray
+{
+    protected function typeToEnforce(): string
+    {
+        return self::SCALAR_BOOLEAN;
+    }
+
+    protected function isMutable(): bool
+    {
+        return false;
+    }
+}

--- a/src/Scalars/ImmutableBooleanList.php
+++ b/src/Scalars/ImmutableBooleanList.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArrays\Scalars;
+
+use TypedArrays\AbstractTypedArray;
+
+final class ImmutableBooleanList extends AbstractTypedArray
+{
+    protected function typeToEnforce(): string
+    {
+        return self::SCALAR_BOOLEAN;
+    }
+
+    protected function isMutable(): bool
+    {
+        return false;
+    }
+
+    protected function collectionType(): string
+    {
+        return self::COLLECTION_TYPE_LIST;
+    }
+}

--- a/src/Scalars/ImmutableBooleanMap.php
+++ b/src/Scalars/ImmutableBooleanMap.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArrays\Scalars;
+
+use TypedArrays\AbstractTypedArray;
+
+final class ImmutableBooleanMap extends AbstractTypedArray
+{
+    protected function typeToEnforce(): string
+    {
+        return self::SCALAR_BOOLEAN;
+    }
+
+    protected function isMutable(): bool
+    {
+        return false;
+    }
+
+    protected function collectionType(): string
+    {
+        return self::COLLECTION_TYPE_MAP;
+    }
+}

--- a/src/Scalars/ImmutableFloatArray.php
+++ b/src/Scalars/ImmutableFloatArray.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace TypedArraysTest\Unit\Fixtures;
+namespace TypedArrays\Scalars;
 
 use TypedArrays\AbstractTypedArray;
 
-final class ImmutableTypedArraySimpleObjects extends AbstractTypedArray
+final class ImmutableFloatArray extends AbstractTypedArray
 {
     protected function typeToEnforce(): string
     {
-        return SimpleObject::class;
+        return self::SCALAR_DOUBLE;
     }
 
     protected function isMutable(): bool

--- a/src/Scalars/ImmutableFloatList.php
+++ b/src/Scalars/ImmutableFloatList.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArrays\Scalars;
+
+use TypedArrays\AbstractTypedArray;
+
+final class ImmutableFloatList extends AbstractTypedArray
+{
+    protected function typeToEnforce(): string
+    {
+        return self::SCALAR_DOUBLE;
+    }
+
+    protected function isMutable(): bool
+    {
+        return false;
+    }
+
+    protected function collectionType(): string
+    {
+        return self::COLLECTION_TYPE_LIST;
+    }
+}

--- a/src/Scalars/ImmutableFloatMap.php
+++ b/src/Scalars/ImmutableFloatMap.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArrays\Scalars;
+
+use TypedArrays\AbstractTypedArray;
+
+final class ImmutableFloatMap extends AbstractTypedArray
+{
+    protected function typeToEnforce(): string
+    {
+        return self::SCALAR_DOUBLE;
+    }
+
+    protected function isMutable(): bool
+    {
+        return false;
+    }
+
+    protected function collectionType(): string
+    {
+        return self::COLLECTION_TYPE_MAP;
+    }
+}

--- a/src/Scalars/ImmutableIntegerArray.php
+++ b/src/Scalars/ImmutableIntegerArray.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArrays\Scalars;
+
+use TypedArrays\AbstractTypedArray;
+
+final class ImmutableIntegerArray extends AbstractTypedArray
+{
+    protected function typeToEnforce(): string
+    {
+        return self::SCALAR_INTEGER;
+    }
+
+    protected function isMutable(): bool
+    {
+        return false;
+    }
+}

--- a/src/Scalars/ImmutableIntegerList.php
+++ b/src/Scalars/ImmutableIntegerList.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArrays\Scalars;
+
+use TypedArrays\AbstractTypedArray;
+
+final class ImmutableIntegerList extends AbstractTypedArray
+{
+    protected function typeToEnforce(): string
+    {
+        return self::SCALAR_INTEGER;
+    }
+
+    protected function isMutable(): bool
+    {
+        return false;
+    }
+
+    protected function collectionType(): string
+    {
+        return self::COLLECTION_TYPE_LIST;
+    }
+}

--- a/src/Scalars/ImmutableIntegerMap.php
+++ b/src/Scalars/ImmutableIntegerMap.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArrays\Scalars;
+
+use TypedArrays\AbstractTypedArray;
+
+final class ImmutableIntegerMap extends AbstractTypedArray
+{
+    protected function typeToEnforce(): string
+    {
+        return self::SCALAR_INTEGER;
+    }
+
+    protected function isMutable(): bool
+    {
+        return false;
+    }
+
+    protected function collectionType(): string
+    {
+        return self::COLLECTION_TYPE_MAP;
+    }
+}

--- a/src/Scalars/ImmutableStringArray.php
+++ b/src/Scalars/ImmutableStringArray.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArrays\Scalars;
+
+use TypedArrays\AbstractTypedArray;
+
+final class ImmutableStringArray extends AbstractTypedArray
+{
+    protected function typeToEnforce(): string
+    {
+        return self::SCALAR_STRING;
+    }
+
+    protected function isMutable(): bool
+    {
+        return false;
+    }
+}

--- a/src/Scalars/ImmutableStringList.php
+++ b/src/Scalars/ImmutableStringList.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArrays\Scalars;
+
+use TypedArrays\AbstractTypedArray;
+
+final class ImmutableStringList extends AbstractTypedArray
+{
+    protected function typeToEnforce(): string
+    {
+        return self::SCALAR_STRING;
+    }
+
+    protected function isMutable(): bool
+    {
+        return false;
+    }
+
+    protected function collectionType(): string
+    {
+        return self::COLLECTION_TYPE_LIST;
+    }
+}

--- a/src/Scalars/ImmutableStringMap.php
+++ b/src/Scalars/ImmutableStringMap.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArrays\Scalars;
+
+use TypedArrays\AbstractTypedArray;
+
+final class ImmutableStringMap extends AbstractTypedArray
+{
+    protected function typeToEnforce(): string
+    {
+        return self::SCALAR_STRING;
+    }
+
+    protected function isMutable(): bool
+    {
+        return false;
+    }
+
+    protected function collectionType(): string
+    {
+        return self::COLLECTION_TYPE_MAP;
+    }
+}

--- a/src/Scalars/MutableBooleanArray.php
+++ b/src/Scalars/MutableBooleanArray.php
@@ -6,10 +6,10 @@ namespace TypedArrays\Scalars;
 
 use TypedArrays\AbstractTypedArray;
 
-final class TypedArrayFloat extends AbstractTypedArray
+final class MutableBooleanArray extends AbstractTypedArray
 {
     protected function typeToEnforce(): string
     {
-        return self::SCALAR_DOUBLE;
+        return self::SCALAR_BOOLEAN;
     }
 }

--- a/src/Scalars/MutableBooleanList.php
+++ b/src/Scalars/MutableBooleanList.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArrays\Scalars;
+
+use TypedArrays\AbstractTypedArray;
+
+final class MutableBooleanList extends AbstractTypedArray
+{
+    protected function typeToEnforce(): string
+    {
+        return self::SCALAR_BOOLEAN;
+    }
+
+    protected function collectionType(): string
+    {
+        return self::COLLECTION_TYPE_LIST;
+    }
+}

--- a/src/Scalars/MutableBooleanMap.php
+++ b/src/Scalars/MutableBooleanMap.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace TypedArraysTest\Unit\Fixtures;
+namespace TypedArrays\Scalars;
 
 use TypedArrays\AbstractTypedArray;
 
-final class MapOfString extends AbstractTypedArray
+final class MutableBooleanMap extends AbstractTypedArray
 {
     protected function typeToEnforce(): string
     {
-        return self::SCALAR_STRING;
+        return self::SCALAR_BOOLEAN;
     }
 
     protected function collectionType(): string

--- a/src/Scalars/MutableFloatArray.php
+++ b/src/Scalars/MutableFloatArray.php
@@ -6,10 +6,10 @@ namespace TypedArrays\Scalars;
 
 use TypedArrays\AbstractTypedArray;
 
-final class TypedArrayBoolean extends AbstractTypedArray
+final class MutableFloatArray extends AbstractTypedArray
 {
     protected function typeToEnforce(): string
     {
-        return self::SCALAR_BOOLEAN;
+        return self::SCALAR_DOUBLE;
     }
 }

--- a/src/Scalars/MutableFloatList.php
+++ b/src/Scalars/MutableFloatList.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArrays\Scalars;
+
+use TypedArrays\AbstractTypedArray;
+
+final class MutableFloatList extends AbstractTypedArray
+{
+    protected function typeToEnforce(): string
+    {
+        return self::SCALAR_DOUBLE;
+    }
+
+    protected function collectionType(): string
+    {
+        return self::COLLECTION_TYPE_LIST;
+    }
+}

--- a/src/Scalars/MutableFloatMap.php
+++ b/src/Scalars/MutableFloatMap.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArrays\Scalars;
+
+use TypedArrays\AbstractTypedArray;
+
+final class MutableFloatMap extends AbstractTypedArray
+{
+    protected function typeToEnforce(): string
+    {
+        return self::SCALAR_DOUBLE;
+    }
+
+    protected function collectionType(): string
+    {
+        return self::COLLECTION_TYPE_MAP;
+    }
+}

--- a/src/Scalars/MutableIntegerArray.php
+++ b/src/Scalars/MutableIntegerArray.php
@@ -6,10 +6,10 @@ namespace TypedArrays\Scalars;
 
 use TypedArrays\AbstractTypedArray;
 
-final class TypedArrayString extends AbstractTypedArray
+final class MutableIntegerArray extends AbstractTypedArray
 {
     protected function typeToEnforce(): string
     {
-        return self::SCALAR_STRING;
+        return self::SCALAR_INTEGER;
     }
 }

--- a/src/Scalars/MutableIntegerList.php
+++ b/src/Scalars/MutableIntegerList.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace TypedArraysTest\Unit\Fixtures;
+namespace TypedArrays\Scalars;
 
 use TypedArrays\AbstractTypedArray;
 
-final class ListOfString extends AbstractTypedArray
+final class MutableIntegerList extends AbstractTypedArray
 {
     protected function typeToEnforce(): string
     {
-        return self::SCALAR_STRING;
+        return self::SCALAR_INTEGER;
     }
 
     protected function collectionType(): string

--- a/src/Scalars/MutableIntegerMap.php
+++ b/src/Scalars/MutableIntegerMap.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArrays\Scalars;
+
+use TypedArrays\AbstractTypedArray;
+
+final class MutableIntegerMap extends AbstractTypedArray
+{
+    protected function typeToEnforce(): string
+    {
+        return self::SCALAR_INTEGER;
+    }
+
+    protected function collectionType(): string
+    {
+        return self::COLLECTION_TYPE_MAP;
+    }
+}

--- a/src/Scalars/MutableStringArray.php
+++ b/src/Scalars/MutableStringArray.php
@@ -6,10 +6,10 @@ namespace TypedArrays\Scalars;
 
 use TypedArrays\AbstractTypedArray;
 
-final class TypedArrayInteger extends AbstractTypedArray
+final class MutableStringArray extends AbstractTypedArray
 {
     protected function typeToEnforce(): string
     {
-        return self::SCALAR_INTEGER;
+        return self::SCALAR_STRING;
     }
 }

--- a/src/Scalars/MutableStringList.php
+++ b/src/Scalars/MutableStringList.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArrays\Scalars;
+
+use TypedArrays\AbstractTypedArray;
+
+final class MutableStringList extends AbstractTypedArray
+{
+    protected function typeToEnforce(): string
+    {
+        return self::SCALAR_STRING;
+    }
+
+    protected function collectionType(): string
+    {
+        return self::COLLECTION_TYPE_LIST;
+    }
+}

--- a/src/Scalars/MutableStringMap.php
+++ b/src/Scalars/MutableStringMap.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArrays\Scalars;
+
+use TypedArrays\AbstractTypedArray;
+
+final class MutableStringMap extends AbstractTypedArray
+{
+    protected function typeToEnforce(): string
+    {
+        return self::SCALAR_STRING;
+    }
+
+    protected function collectionType(): string
+    {
+        return self::COLLECTION_TYPE_MAP;
+    }
+}

--- a/tests/Unit/Fixtures/ImmutableSimpleObjectArray.php
+++ b/tests/Unit/Fixtures/ImmutableSimpleObjectArray.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Fixtures;
+
+use TypedArrays\AbstractTypedArray;
+
+final class ImmutableSimpleObjectArray extends AbstractTypedArray
+{
+    protected function typeToEnforce(): string
+    {
+        return SimpleObject::class;
+    }
+
+    protected function isMutable(): bool
+    {
+        return false;
+    }
+}

--- a/tests/Unit/Fixtures/MutableSimpleObjectList.php
+++ b/tests/Unit/Fixtures/MutableSimpleObjectList.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Fixtures;
+
+use TypedArrays\AbstractTypedArray;
+
+final class MutableSimpleObjectList extends AbstractTypedArray
+{
+    protected function typeToEnforce(): string
+    {
+        return SimpleObject::class;
+    }
+
+    protected function collectionType(): string
+    {
+        return self::COLLECTION_TYPE_LIST;
+    }
+}

--- a/tests/Unit/Fixtures/MutableSimpleObjectMap.php
+++ b/tests/Unit/Fixtures/MutableSimpleObjectMap.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Fixtures;
+
+use TypedArrays\AbstractTypedArray;
+
+final class MutableSimpleObjectMap extends AbstractTypedArray
+{
+    protected function typeToEnforce(): string
+    {
+        return SimpleObject::class;
+    }
+
+    protected function collectionType(): string
+    {
+        return self::COLLECTION_TYPE_MAP;
+    }
+}

--- a/tests/Unit/ImmutabilityTest.php
+++ b/tests/Unit/ImmutabilityTest.php
@@ -11,7 +11,7 @@ use TypedArraysTest\Unit\Fixtures\SimpleObject;
 
 final class ImmutabilityTest extends TestCase
 {
-    public function testImmutabilityOfSet(): void
+    public function test_immutability_of_set(): void
     {
         $test = new ImmutableSimpleObjectArray([new SimpleObject()]);
 
@@ -21,7 +21,7 @@ final class ImmutabilityTest extends TestCase
         $test[] = new SimpleObject();
     }
 
-    public function testImmutabilityOfUnset(): void
+    public function test_immutability_of_unset(): void
     {
         $test = new ImmutableSimpleObjectArray([new SimpleObject()]);
 

--- a/tests/Unit/ImmutabilityTest.php
+++ b/tests/Unit/ImmutabilityTest.php
@@ -6,14 +6,14 @@ namespace TypedArraysTest\Unit;
 
 use PHPUnit\Framework\TestCase;
 use TypedArrays\Exceptions\ImmutabilityException;
-use TypedArraysTest\Unit\Fixtures\ImmutableTypedArraySimpleObjects;
+use TypedArraysTest\Unit\Fixtures\ImmutableSimpleObjectArray;
 use TypedArraysTest\Unit\Fixtures\SimpleObject;
 
 final class ImmutabilityTest extends TestCase
 {
     public function testImmutabilityOfSet(): void
     {
-        $test = new ImmutableTypedArraySimpleObjects([new SimpleObject()]);
+        $test = new ImmutableSimpleObjectArray([new SimpleObject()]);
 
         $this->expectException(ImmutabilityException::class);
         $this->expectExceptionMessage('This TypedArray object is immutable.');
@@ -23,7 +23,7 @@ final class ImmutabilityTest extends TestCase
 
     public function testImmutabilityOfUnset(): void
     {
-        $test = new ImmutableTypedArraySimpleObjects([new SimpleObject()]);
+        $test = new ImmutableSimpleObjectArray([new SimpleObject()]);
 
         $this->expectException(ImmutabilityException::class);
         $this->expectExceptionMessage('This TypedArray object is immutable.');

--- a/tests/Unit/ListTest.php
+++ b/tests/Unit/ListTest.php
@@ -10,21 +10,21 @@ use TypedArraysTest\Unit\Fixtures\ListOfString;
 
 final class ListTest extends TestCase
 {
-    public function testListConstructorThrowsAnExceptionWhenKeysAreSpecified(): void
+    public function test_list_constructor_throws_an_exception_when_keys_are_specified(): void
     {
         $this->expectExceptionObject(ListException::keysNotAllowed());
 
         new ListOfString(['invalid' => 'test']);
     }
 
-    public function testListConstructorDoesNotThrowAnyExceptionWhenKeysAreNotSpecified(): void
+    public function test_list_constructor_does_not_throw_any_exception_when_keys_are_not_specified(): void
     {
         $test = new ListOfString(['valid', 'test']);
 
         self::assertEquals('valid', $test[0]);
     }
 
-    public function testListSetterThrowsAnExceptionWhenKeyIsSpecified(): void
+    public function test_list_setter_throws_an_exception_when_key_is_specified(): void
     {
         $test = new ListOfString(['test']);
 
@@ -33,7 +33,7 @@ final class ListTest extends TestCase
         $test['key'] = 'invalid';
     }
 
-    public function testListSetterDoesNotThrowAnyExceptionWhenKeyIsNotSpecified(): void
+    public function test_list_setter_does_not_throw_any_exception_when_key_is_not_specified(): void
     {
         $test = new ListOfString(['test']);
 
@@ -42,7 +42,7 @@ final class ListTest extends TestCase
         self::assertEquals('valid', $test[1]);
     }
 
-    public function testListSetterDoesNotThrowAnyExceptionWhenAnElementIsModifiedByKey(): void
+    public function test_list_setter_does_not_throw_any_exception_when_an_element_is_modified_by_key(): void
     {
         $test = new ListOfString(['unmodified']);
 

--- a/tests/Unit/ListTest.php
+++ b/tests/Unit/ListTest.php
@@ -20,9 +20,11 @@ final class ListTest extends TestCase
 
     public function test_list_constructor_does_not_throw_any_exception_when_keys_are_not_specified(): void
     {
-        $test = new MutableSimpleObjectList([new SimpleObject('valid')]);
+        $expected = new SimpleObject('valid');
 
-        self::assertEquals(new SimpleObject('valid'), $test[0]);
+        $test = new MutableSimpleObjectList([$expected]);
+
+        self::assertSame($expected, $test[0]);
     }
 
     public function test_list_setter_throws_an_exception_when_key_is_specified(): void
@@ -36,19 +38,21 @@ final class ListTest extends TestCase
 
     public function test_list_setter_does_not_throw_any_exception_when_key_is_not_specified(): void
     {
-        $test = new MutableSimpleObjectList([new SimpleObject()]);
+        $test = new MutableSimpleObjectList([new SimpleObject('unmodified')]);
 
-        $test[] = new SimpleObject('valid');
+        $expected = new SimpleObject('modified');
+        $test[] = $expected;
 
-        self::assertEquals(new SimpleObject('valid'), $test[1]);
+        self::assertSame($expected, $test[1]);
     }
 
     public function test_list_setter_does_not_throw_any_exception_when_an_element_is_modified_by_key(): void
     {
         $test = new MutableSimpleObjectList([new SimpleObject('unmodified')]);
 
-        $test[0] = new SimpleObject('modified');
+        $expected = new SimpleObject('modified');
+        $test[0] = $expected;
 
-        self::assertEquals(new SimpleObject('modified'), $test[0]);
+        self::assertSame($expected, $test[0]);
     }
 }

--- a/tests/Unit/ListTest.php
+++ b/tests/Unit/ListTest.php
@@ -6,7 +6,8 @@ namespace TypedArraysTest\Unit;
 
 use PHPUnit\Framework\TestCase;
 use TypedArrays\Exceptions\ListException;
-use TypedArraysTest\Unit\Fixtures\ListOfString;
+use TypedArraysTest\Unit\Fixtures\MutableSimpleObjectList;
+use TypedArraysTest\Unit\Fixtures\SimpleObject;
 
 final class ListTest extends TestCase
 {
@@ -14,40 +15,40 @@ final class ListTest extends TestCase
     {
         $this->expectExceptionObject(ListException::keysNotAllowed());
 
-        new ListOfString(['invalid' => 'test']);
+        new MutableSimpleObjectList(['invalid' => new SimpleObject()]);
     }
 
     public function test_list_constructor_does_not_throw_any_exception_when_keys_are_not_specified(): void
     {
-        $test = new ListOfString(['valid', 'test']);
+        $test = new MutableSimpleObjectList([new SimpleObject('valid')]);
 
-        self::assertEquals('valid', $test[0]);
+        self::assertEquals(new SimpleObject('valid'), $test[0]);
     }
 
     public function test_list_setter_throws_an_exception_when_key_is_specified(): void
     {
-        $test = new ListOfString(['test']);
+        $test = new MutableSimpleObjectList([new SimpleObject()]);
 
         $this->expectExceptionObject(ListException::keysNotAllowed());
 
-        $test['key'] = 'invalid';
+        $test['invalid'] = new SimpleObject();
     }
 
     public function test_list_setter_does_not_throw_any_exception_when_key_is_not_specified(): void
     {
-        $test = new ListOfString(['test']);
+        $test = new MutableSimpleObjectList([new SimpleObject()]);
 
-        $test[] = 'valid';
+        $test[] = new SimpleObject('valid');
 
-        self::assertEquals('valid', $test[1]);
+        self::assertEquals(new SimpleObject('valid'), $test[1]);
     }
 
     public function test_list_setter_does_not_throw_any_exception_when_an_element_is_modified_by_key(): void
     {
-        $test = new ListOfString(['unmodified']);
+        $test = new MutableSimpleObjectList([new SimpleObject('unmodified')]);
 
-        $test[0] = 'modified';
+        $test[0] = new SimpleObject('modified');
 
-        self::assertEquals('modified', $test[0]);
+        self::assertEquals(new SimpleObject('modified'), $test[0]);
     }
 }

--- a/tests/Unit/MapTest.php
+++ b/tests/Unit/MapTest.php
@@ -10,21 +10,21 @@ use TypedArraysTest\Unit\Fixtures\MapOfString;
 
 final class MapTest extends TestCase
 {
-    public function testMapConstructorThrowsAnExceptionWhenKeysAreNotSpecified(): void
+    public function test_map_constructor_throws_an_exception_when_keys_are_not_specified(): void
     {
         $this->expectExceptionObject(MapException::keysRequired());
 
         new MapOfString(['invalid']);
     }
 
-    public function testMapConstructorDoesNotThrowAnyExceptionWhenKeysAreSpecified(): void
+    public function test_map_constructor_does_not_throw_any_exception_when_keys_are_specified(): void
     {
         $test = new MapOfString(['valid' => 'test']);
 
         self::assertEquals('test', $test['valid']);
     }
 
-    public function testMapSetterThrowsAnExceptionWhenKeyIsNotSpecified(): void
+    public function test_map_setter_throws_an_exception_when_key_is_not_specified(): void
     {
         $test = new MapOfString(['valid' => 'test']);
 
@@ -33,7 +33,7 @@ final class MapTest extends TestCase
         $test[] = 'invalid';
     }
 
-    public function testMapSetterDoesNotThrowAnyExceptionWhenKeyIsSpecified(): void
+    public function test_map_setter_does_not_throw_any_exception_when_key_is_specified(): void
     {
         $test = new MapOfString(['key' => 'test']);
 

--- a/tests/Unit/MapTest.php
+++ b/tests/Unit/MapTest.php
@@ -6,7 +6,8 @@ namespace TypedArraysTest\Unit;
 
 use PHPUnit\Framework\TestCase;
 use TypedArrays\Exceptions\MapException;
-use TypedArraysTest\Unit\Fixtures\MapOfString;
+use TypedArraysTest\Unit\Fixtures\MutableSimpleObjectMap;
+use TypedArraysTest\Unit\Fixtures\SimpleObject;
 
 final class MapTest extends TestCase
 {
@@ -14,31 +15,40 @@ final class MapTest extends TestCase
     {
         $this->expectExceptionObject(MapException::keysRequired());
 
-        new MapOfString(['invalid']);
+        new MutableSimpleObjectMap([new SimpleObject('invalid')]);
     }
 
     public function test_map_constructor_does_not_throw_any_exception_when_keys_are_specified(): void
     {
-        $test = new MapOfString(['valid' => 'test']);
+        $expected = new SimpleObject('test');
+        $test = new MutableSimpleObjectMap(['valid' => $expected]);
 
-        self::assertSame('test', $test['valid']);
+        self::assertSame($expected, $test['valid']);
+    }
+
+    public function test_map_constructor_doest_not_throw_any_exception_when_empty_array_given(): void
+    {
+        $test = new MutableSimpleObjectMap([]);
+
+        self::assertEmpty((array) $test);
     }
 
     public function test_map_setter_throws_an_exception_when_key_is_not_specified(): void
     {
-        $test = new MapOfString(['valid' => 'test']);
+        $test = new MutableSimpleObjectMap(['valid' => new SimpleObject()]);
 
         $this->expectExceptionObject(MapException::keysRequired());
 
-        $test[] = 'invalid';
+        $test[] = new SimpleObject('invalid');
     }
 
     public function test_map_setter_does_not_throw_any_exception_when_key_is_specified(): void
     {
-        $test = new MapOfString(['key' => 'test']);
+        $test = new MutableSimpleObjectMap(['key' => new SimpleObject()]);
 
-        $test['valid'] = 'expected';
+        $expected = new SimpleObject('expected');
+        $test['valid'] = $expected;
 
-        self::assertSame('expected', $test['valid']);
+        self::assertSame($expected, $test['valid']);
     }
 }

--- a/tests/Unit/MapTest.php
+++ b/tests/Unit/MapTest.php
@@ -21,7 +21,7 @@ final class MapTest extends TestCase
     {
         $test = new MapOfString(['valid' => 'test']);
 
-        self::assertEquals('test', $test['valid']);
+        self::assertSame('test', $test['valid']);
     }
 
     public function test_map_setter_throws_an_exception_when_key_is_not_specified(): void
@@ -39,6 +39,6 @@ final class MapTest extends TestCase
 
         $test['valid'] = 'expected';
 
-        self::assertEquals('expected', $test['valid']);
+        self::assertSame('expected', $test['valid']);
     }
 }

--- a/tests/Unit/Scalars/ImmutableBooleanArrayTest.php
+++ b/tests/Unit/Scalars/ImmutableBooleanArrayTest.php
@@ -32,6 +32,26 @@ final class ImmutableBooleanArrayTest extends TestCase
         new ImmutableBooleanArray($arguments);
     }
 
+    public function test_immutability_of_set(): void
+    {
+        $test = new ImmutableBooleanArray([true]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        $test[] = false;
+    }
+
+    public function test_immutability_of_unset(): void
+    {
+        $test = new ImmutableBooleanArray([false]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        unset($test[0]);
+    }
+
     public function providerInvalidScalarInputType(): Generator
     {
         yield 'Receiving integers' => [
@@ -53,25 +73,5 @@ final class ImmutableBooleanArrayTest extends TestCase
         yield 'Receiving a mix of all scalars' => [
             'arguments' => [true, 1, 2.3, 'string', new stdClass()],
         ];
-    }
-
-    public function test_immutability_of_set(): void
-    {
-        $test = new ImmutableBooleanArray([true]);
-
-        $this->expectException(ImmutabilityException::class);
-        $this->expectExceptionMessage('This TypedArray object is immutable.');
-
-        $test[] = false;
-    }
-
-    public function test_immutability_of_unset(): void
-    {
-        $test = new ImmutableBooleanArray([false]);
-
-        $this->expectException(ImmutabilityException::class);
-        $this->expectExceptionMessage('This TypedArray object is immutable.');
-
-        unset($test[0]);
     }
 }

--- a/tests/Unit/Scalars/ImmutableBooleanArrayTest.php
+++ b/tests/Unit/Scalars/ImmutableBooleanArrayTest.php
@@ -14,7 +14,7 @@ use TypedArrays\Scalars\ImmutableBooleanArray;
 
 final class ImmutableBooleanArrayTest extends TestCase
 {
-    public function testConstruct(): void
+    public function test_construct(): void
     {
         $test = new ImmutableBooleanArray([true]);
 
@@ -25,7 +25,7 @@ final class ImmutableBooleanArrayTest extends TestCase
     /**
      * @dataProvider providerInvalidScalarInputType
      */
-    public function testInvalidScalarInputType(array $arguments): void
+    public function test_invalid_scalar_input_type(array $arguments): void
     {
         $this->expectException(InvalidTypeException::class);
 
@@ -55,7 +55,7 @@ final class ImmutableBooleanArrayTest extends TestCase
         ];
     }
 
-    public function testImmutabilityOfSet(): void
+    public function test_immutability_of_set(): void
     {
         $test = new ImmutableBooleanArray([true]);
 
@@ -65,7 +65,7 @@ final class ImmutableBooleanArrayTest extends TestCase
         $test[] = false;
     }
 
-    public function testImmutabilityOfUnset(): void
+    public function test_immutability_of_unset(): void
     {
         $test = new ImmutableBooleanArray([false]);
 

--- a/tests/Unit/Scalars/ImmutableBooleanArrayTest.php
+++ b/tests/Unit/Scalars/ImmutableBooleanArrayTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Scalars;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypedArrays\AbstractTypedArray;
+use TypedArrays\Exceptions\ImmutabilityException;
+use TypedArrays\Exceptions\InvalidTypeException;
+use TypedArrays\Scalars\ImmutableBooleanArray;
+
+final class ImmutableBooleanArrayTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $test = new ImmutableBooleanArray([true]);
+
+        self::assertInstanceOf(ImmutableBooleanArray::class, $test);
+        self::assertInstanceOf(AbstractTypedArray::class, $test);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputType
+     */
+    public function testInvalidScalarInputType(array $arguments): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        new ImmutableBooleanArray($arguments);
+    }
+
+    public function providerInvalidScalarInputType(): Generator
+    {
+        yield 'Receiving integers' => [
+            'arguments' => [1, 2],
+        ];
+
+        yield 'Receiving floats' => [
+            'arguments' => [1.23, 4.56],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => [new stdClass(), new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['str1', 'str2'],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => [true, 1, 2.3, 'string', new stdClass()],
+        ];
+    }
+
+    public function testImmutabilityOfSet(): void
+    {
+        $test = new ImmutableBooleanArray([true]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        $test[] = false;
+    }
+
+    public function testImmutabilityOfUnset(): void
+    {
+        $test = new ImmutableBooleanArray([false]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        unset($test[0]);
+    }
+}

--- a/tests/Unit/Scalars/ImmutableBooleanListTest.php
+++ b/tests/Unit/Scalars/ImmutableBooleanListTest.php
@@ -87,6 +87,6 @@ final class ImmutableBooleanListTest extends TestCase
     {
         $test = new ImmutableBooleanList([true]);
 
-        self::assertEquals(true, $test[0]);
+        self::assertSame(true, $test[0]);
     }
 }

--- a/tests/Unit/Scalars/ImmutableBooleanListTest.php
+++ b/tests/Unit/Scalars/ImmutableBooleanListTest.php
@@ -87,6 +87,6 @@ final class ImmutableBooleanListTest extends TestCase
     {
         $test = new ImmutableBooleanList([true]);
 
-        self::assertSame(true, $test[0]);
+        self::assertTrue($test[0]);
     }
 }

--- a/tests/Unit/Scalars/ImmutableBooleanListTest.php
+++ b/tests/Unit/Scalars/ImmutableBooleanListTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Scalars;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypedArrays\AbstractTypedArray;
+use TypedArrays\Exceptions\ImmutabilityException;
+use TypedArrays\Exceptions\InvalidTypeException;
+use TypedArrays\Exceptions\ListException;
+use TypedArrays\Scalars\ImmutableBooleanList;
+
+final class ImmutableBooleanListTest extends TestCase
+{
+    public function test_construct(): void
+    {
+        $test = new ImmutableBooleanList([true]);
+
+        self::assertInstanceOf(ImmutableBooleanList::class, $test);
+        self::assertInstanceOf(AbstractTypedArray::class, $test);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputType
+     */
+    public function test_invalid_scalar_input_type(array $arguments): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        new ImmutableBooleanList($arguments);
+    }
+
+    public function providerInvalidScalarInputType(): Generator
+    {
+        yield 'Receiving integers' => [
+            'arguments' => [1, 2],
+        ];
+
+        yield 'Receiving floats' => [
+            'arguments' => [1.23, 4.56],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => [new stdClass(), new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['str1', 'str2'],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => [true, 1, 2.3, 'string', new stdClass()],
+        ];
+    }
+
+    public function test_immutability_of_set(): void
+    {
+        $test = new ImmutableBooleanList([true]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        $test[] = false;
+    }
+
+    public function test_immutability_of_unset(): void
+    {
+        $test = new ImmutableBooleanList([false]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        unset($test[0]);
+    }
+
+    public function test_list_constructor_throws_an_exception_when_keys_are_specified(): void
+    {
+        $this->expectExceptionObject(ListException::keysNotAllowed());
+
+        new ImmutableBooleanList(['invalid' => false]);
+    }
+
+    public function test_list_constructor_does_not_throw_any_exception_when_keys_are_not_specified(): void
+    {
+        $test = new ImmutableBooleanList([true]);
+
+        self::assertEquals(true, $test[0]);
+    }
+}

--- a/tests/Unit/Scalars/ImmutableBooleanListTest.php
+++ b/tests/Unit/Scalars/ImmutableBooleanListTest.php
@@ -33,29 +33,6 @@ final class ImmutableBooleanListTest extends TestCase
         new ImmutableBooleanList($arguments);
     }
 
-    public function providerInvalidScalarInputType(): Generator
-    {
-        yield 'Receiving integers' => [
-            'arguments' => [1, 2],
-        ];
-
-        yield 'Receiving floats' => [
-            'arguments' => [1.23, 4.56],
-        ];
-
-        yield 'Receiving stdClasses' => [
-            'arguments' => [new stdClass(), new stdClass()],
-        ];
-
-        yield 'Receiving strings' => [
-            'arguments' => ['str1', 'str2'],
-        ];
-
-        yield 'Receiving a mix of all scalars' => [
-            'arguments' => [true, 1, 2.3, 'string', new stdClass()],
-        ];
-    }
-
     public function test_immutability_of_set(): void
     {
         $test = new ImmutableBooleanList([true]);
@@ -88,5 +65,28 @@ final class ImmutableBooleanListTest extends TestCase
         $test = new ImmutableBooleanList([true]);
 
         self::assertTrue($test[0]);
+    }
+
+    public function providerInvalidScalarInputType(): Generator
+    {
+        yield 'Receiving integers' => [
+            'arguments' => [1, 2],
+        ];
+
+        yield 'Receiving floats' => [
+            'arguments' => [1.23, 4.56],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => [new stdClass(), new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['str1', 'str2'],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => [true, 1, 2.3, 'string', new stdClass()],
+        ];
     }
 }

--- a/tests/Unit/Scalars/ImmutableBooleanMapTest.php
+++ b/tests/Unit/Scalars/ImmutableBooleanMapTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Scalars;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypedArrays\AbstractTypedArray;
+use TypedArrays\Exceptions\ImmutabilityException;
+use TypedArrays\Exceptions\InvalidTypeException;
+use TypedArrays\Exceptions\MapException;
+use TypedArrays\Scalars\ImmutableBooleanMap;
+
+final class ImmutableBooleanMapTest extends TestCase
+{
+    public function test_construct(): void
+    {
+        $test = new ImmutableBooleanMap(['key' => true]);
+
+        self::assertInstanceOf(ImmutableBooleanMap::class, $test);
+        self::assertInstanceOf(AbstractTypedArray::class, $test);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputType
+     */
+    public function test_invalid_scalar_input_type(array $arguments): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        new ImmutableBooleanMap($arguments);
+    }
+
+    public function providerInvalidScalarInputType(): Generator
+    {
+        yield 'Receiving integers' => [
+            'arguments' => ['key1' => 1, 'key2' => 2],
+        ];
+
+        yield 'Receiving floats' => [
+            'arguments' => ['key1' => 1.23, 'key2' => 4.56],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => ['key1' => new stdClass(), 'key2' => new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['key1' => 'str1', 'key2' => 'str2'],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => ['key1' => true, 'key2' => 1, 'key3' => 2.3, 'key4' => 'string', 'key5' => new stdClass()],
+        ];
+    }
+
+    public function test_immutability_of_set(): void
+    {
+        $test = new ImmutableBooleanMap(['key' => true]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        $test['invalid'] = false;
+    }
+
+    public function test_immutability_of_unset(): void
+    {
+        $test = new ImmutableBooleanMap(['key' => false]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        unset($test['key']);
+    }
+
+    public function test_map_constructor_throws_an_exception_when_keys_are_not_specified(): void
+    {
+        $this->expectExceptionObject(MapException::keysRequired());
+
+        new ImmutableBooleanMap([false]);
+    }
+
+    public function test_map_constructor_does_not_throw_any_exception_when_keys_are_specified(): void
+    {
+        $test = new ImmutableBooleanMap(['valid' => true]);
+
+        self::assertSame(true, $test['valid']);
+    }
+
+    public function test_map_constructor_doest_not_throw_any_exception_when_empty_array_given(): void
+    {
+        $test = new ImmutableBooleanMap([]);
+
+        self::assertEmpty((array) $test);
+    }
+}

--- a/tests/Unit/Scalars/ImmutableBooleanMapTest.php
+++ b/tests/Unit/Scalars/ImmutableBooleanMapTest.php
@@ -87,7 +87,7 @@ final class ImmutableBooleanMapTest extends TestCase
     {
         $test = new ImmutableBooleanMap(['valid' => true]);
 
-        self::assertSame(true, $test['valid']);
+        self::assertTrue($test['valid']);
     }
 
     public function test_map_constructor_doest_not_throw_any_exception_when_empty_array_given(): void

--- a/tests/Unit/Scalars/ImmutableBooleanMapTest.php
+++ b/tests/Unit/Scalars/ImmutableBooleanMapTest.php
@@ -33,29 +33,6 @@ final class ImmutableBooleanMapTest extends TestCase
         new ImmutableBooleanMap($arguments);
     }
 
-    public function providerInvalidScalarInputType(): Generator
-    {
-        yield 'Receiving integers' => [
-            'arguments' => ['key1' => 1, 'key2' => 2],
-        ];
-
-        yield 'Receiving floats' => [
-            'arguments' => ['key1' => 1.23, 'key2' => 4.56],
-        ];
-
-        yield 'Receiving stdClasses' => [
-            'arguments' => ['key1' => new stdClass(), 'key2' => new stdClass()],
-        ];
-
-        yield 'Receiving strings' => [
-            'arguments' => ['key1' => 'str1', 'key2' => 'str2'],
-        ];
-
-        yield 'Receiving a mix of all scalars' => [
-            'arguments' => ['key1' => true, 'key2' => 1, 'key3' => 2.3, 'key4' => 'string', 'key5' => new stdClass()],
-        ];
-    }
-
     public function test_immutability_of_set(): void
     {
         $test = new ImmutableBooleanMap(['key' => true]);
@@ -95,5 +72,28 @@ final class ImmutableBooleanMapTest extends TestCase
         $test = new ImmutableBooleanMap([]);
 
         self::assertEmpty((array) $test);
+    }
+
+    public function providerInvalidScalarInputType(): Generator
+    {
+        yield 'Receiving integers' => [
+            'arguments' => ['key1' => 1, 'key2' => 2],
+        ];
+
+        yield 'Receiving floats' => [
+            'arguments' => ['key1' => 1.23, 'key2' => 4.56],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => ['key1' => new stdClass(), 'key2' => new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['key1' => 'str1', 'key2' => 'str2'],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => ['key1' => true, 'key2' => 1, 'key3' => 2.3, 'key4' => 'string', 'key5' => new stdClass()],
+        ];
     }
 }

--- a/tests/Unit/Scalars/ImmutableFloatArrayTest.php
+++ b/tests/Unit/Scalars/ImmutableFloatArrayTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Scalars;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypedArrays\AbstractTypedArray;
+use TypedArrays\Exceptions\ImmutabilityException;
+use TypedArrays\Exceptions\InvalidTypeException;
+use TypedArrays\Scalars\ImmutableFloatArray;
+
+final class ImmutableFloatArrayTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $test = new ImmutableFloatArray([1.5]);
+
+        self::assertInstanceOf(ImmutableFloatArray::class, $test);
+        self::assertInstanceOf(AbstractTypedArray::class, $test);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputType
+     */
+    public function testInvalidScalarInputType(array $arguments): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        new ImmutableFloatArray($arguments);
+    }
+
+    public function providerInvalidScalarInputType(): Generator
+    {
+        yield 'Receiving integers' => [
+            'arguments' => [1, 2],
+        ];
+
+        yield 'Receiving booleans' => [
+            'arguments' => [true, false],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => [new stdClass(), new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['str1', 'str2'],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => [true, 1, 2.3, 'string', new stdClass()],
+        ];
+    }
+
+    public function testImmutabilityOfSet(): void
+    {
+        $test = new ImmutableFloatArray([3.14]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        $test[] = 6.28;
+    }
+
+    public function testImmutabilityOfUnset(): void
+    {
+        $test = new ImmutableFloatArray([1.618]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        unset($test[0]);
+    }
+}

--- a/tests/Unit/Scalars/ImmutableFloatArrayTest.php
+++ b/tests/Unit/Scalars/ImmutableFloatArrayTest.php
@@ -32,6 +32,26 @@ final class ImmutableFloatArrayTest extends TestCase
         new ImmutableFloatArray($arguments);
     }
 
+    public function test_immutability_of_set(): void
+    {
+        $test = new ImmutableFloatArray([3.14]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        $test[] = 6.28;
+    }
+
+    public function test_immutability_of_unset(): void
+    {
+        $test = new ImmutableFloatArray([1.618]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        unset($test[0]);
+    }
+
     public function providerInvalidScalarInputType(): Generator
     {
         yield 'Receiving integers' => [
@@ -53,25 +73,5 @@ final class ImmutableFloatArrayTest extends TestCase
         yield 'Receiving a mix of all scalars' => [
             'arguments' => [true, 1, 2.3, 'string', new stdClass()],
         ];
-    }
-
-    public function test_immutability_of_set(): void
-    {
-        $test = new ImmutableFloatArray([3.14]);
-
-        $this->expectException(ImmutabilityException::class);
-        $this->expectExceptionMessage('This TypedArray object is immutable.');
-
-        $test[] = 6.28;
-    }
-
-    public function test_immutability_of_unset(): void
-    {
-        $test = new ImmutableFloatArray([1.618]);
-
-        $this->expectException(ImmutabilityException::class);
-        $this->expectExceptionMessage('This TypedArray object is immutable.');
-
-        unset($test[0]);
     }
 }

--- a/tests/Unit/Scalars/ImmutableFloatArrayTest.php
+++ b/tests/Unit/Scalars/ImmutableFloatArrayTest.php
@@ -14,7 +14,7 @@ use TypedArrays\Scalars\ImmutableFloatArray;
 
 final class ImmutableFloatArrayTest extends TestCase
 {
-    public function testConstruct(): void
+    public function test_construct(): void
     {
         $test = new ImmutableFloatArray([1.5]);
 
@@ -25,7 +25,7 @@ final class ImmutableFloatArrayTest extends TestCase
     /**
      * @dataProvider providerInvalidScalarInputType
      */
-    public function testInvalidScalarInputType(array $arguments): void
+    public function test_invalid_scalar_input_type(array $arguments): void
     {
         $this->expectException(InvalidTypeException::class);
 
@@ -55,7 +55,7 @@ final class ImmutableFloatArrayTest extends TestCase
         ];
     }
 
-    public function testImmutabilityOfSet(): void
+    public function test_immutability_of_set(): void
     {
         $test = new ImmutableFloatArray([3.14]);
 
@@ -65,7 +65,7 @@ final class ImmutableFloatArrayTest extends TestCase
         $test[] = 6.28;
     }
 
-    public function testImmutabilityOfUnset(): void
+    public function test_immutability_of_unset(): void
     {
         $test = new ImmutableFloatArray([1.618]);
 

--- a/tests/Unit/Scalars/ImmutableFloatListTest.php
+++ b/tests/Unit/Scalars/ImmutableFloatListTest.php
@@ -87,6 +87,6 @@ final class ImmutableFloatListTest extends TestCase
     {
         $test = new ImmutableFloatList([137.5]);
 
-        self::assertEquals(137.5, $test[0]);
+        self::assertSame(137.5, $test[0]);
     }
 }

--- a/tests/Unit/Scalars/ImmutableFloatListTest.php
+++ b/tests/Unit/Scalars/ImmutableFloatListTest.php
@@ -33,29 +33,6 @@ final class ImmutableFloatListTest extends TestCase
         new ImmutableFloatList($arguments);
     }
 
-    public function providerInvalidScalarInputType(): Generator
-    {
-        yield 'Receiving integers' => [
-            'arguments' => [1, 2],
-        ];
-
-        yield 'Receiving booleans' => [
-            'arguments' => [true, false],
-        ];
-
-        yield 'Receiving stdClasses' => [
-            'arguments' => [new stdClass(), new stdClass()],
-        ];
-
-        yield 'Receiving strings' => [
-            'arguments' => ['str1', 'str2'],
-        ];
-
-        yield 'Receiving a mix of all scalars' => [
-            'arguments' => [true, 1, 2.3, 'string', new stdClass()],
-        ];
-    }
-
     public function test_immutability_of_set(): void
     {
         $test = new ImmutableFloatList([3.14]);
@@ -88,5 +65,28 @@ final class ImmutableFloatListTest extends TestCase
         $test = new ImmutableFloatList([137.5]);
 
         self::assertSame(137.5, $test[0]);
+    }
+
+    public function providerInvalidScalarInputType(): Generator
+    {
+        yield 'Receiving integers' => [
+            'arguments' => [1, 2],
+        ];
+
+        yield 'Receiving booleans' => [
+            'arguments' => [true, false],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => [new stdClass(), new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['str1', 'str2'],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => [true, 1, 2.3, 'string', new stdClass()],
+        ];
     }
 }

--- a/tests/Unit/Scalars/ImmutableFloatListTest.php
+++ b/tests/Unit/Scalars/ImmutableFloatListTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Scalars;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypedArrays\AbstractTypedArray;
+use TypedArrays\Exceptions\ImmutabilityException;
+use TypedArrays\Exceptions\InvalidTypeException;
+use TypedArrays\Exceptions\ListException;
+use TypedArrays\Scalars\ImmutableFloatList;
+
+final class ImmutableFloatListTest extends TestCase
+{
+    public function test_construct(): void
+    {
+        $test = new ImmutableFloatList([1.5]);
+
+        self::assertInstanceOf(ImmutableFloatList::class, $test);
+        self::assertInstanceOf(AbstractTypedArray::class, $test);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputType
+     */
+    public function test_invalid_scalar_input_type(array $arguments): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        new ImmutableFloatList($arguments);
+    }
+
+    public function providerInvalidScalarInputType(): Generator
+    {
+        yield 'Receiving integers' => [
+            'arguments' => [1, 2],
+        ];
+
+        yield 'Receiving booleans' => [
+            'arguments' => [true, false],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => [new stdClass(), new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['str1', 'str2'],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => [true, 1, 2.3, 'string', new stdClass()],
+        ];
+    }
+
+    public function test_immutability_of_set(): void
+    {
+        $test = new ImmutableFloatList([3.14]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        $test[] = 6.28;
+    }
+
+    public function test_immutability_of_unset(): void
+    {
+        $test = new ImmutableFloatList([1.618]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        unset($test[0]);
+    }
+
+    public function test_list_constructor_throws_an_exception_when_keys_are_specified(): void
+    {
+        $this->expectExceptionObject(ListException::keysNotAllowed());
+
+        new ImmutableFloatList(['invalid' => 2.718]);
+    }
+
+    public function test_list_constructor_does_not_throw_any_exception_when_keys_are_not_specified(): void
+    {
+        $test = new ImmutableFloatList([137.5]);
+
+        self::assertEquals(137.5, $test[0]);
+    }
+}

--- a/tests/Unit/Scalars/ImmutableFloatMapTest.php
+++ b/tests/Unit/Scalars/ImmutableFloatMapTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Scalars;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypedArrays\AbstractTypedArray;
+use TypedArrays\Exceptions\ImmutabilityException;
+use TypedArrays\Exceptions\InvalidTypeException;
+use TypedArrays\Exceptions\MapException;
+use TypedArrays\Scalars\ImmutableFloatMap;
+
+final class ImmutableFloatMapTest extends TestCase
+{
+    public function test_construct(): void
+    {
+        $test = new ImmutableFloatMap(['key' => 1.5]);
+
+        self::assertInstanceOf(ImmutableFloatMap::class, $test);
+        self::assertInstanceOf(AbstractTypedArray::class, $test);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputType
+     */
+    public function test_invalid_scalar_input_type(array $arguments): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        new ImmutableFloatMap($arguments);
+    }
+
+    public function providerInvalidScalarInputType(): Generator
+    {
+        yield 'Receiving integers' => [
+            'arguments' => ['key1' => 1, 'key2' => 2],
+        ];
+
+        yield 'Receiving booleans' => [
+            'arguments' => ['key1' => true, 'key2' => false],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => ['key1' => new stdClass(), 'key2' => new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['key1' => 'str1', 'key2' => 'str2'],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => ['key1' => true, 'key2' => 1, 'key3' => 2.3, 'key4' => 'string', 'key5' => new stdClass()],
+        ];
+    }
+
+    public function test_immutability_of_set(): void
+    {
+        $test = new ImmutableFloatMap(['key' => 3.14]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        $test['invalid'] = 6.28;
+    }
+
+    public function test_immutability_of_unset(): void
+    {
+        $test = new ImmutableFloatMap(['key' => 1.618]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        unset($test['key']);
+    }
+
+    public function test_map_constructor_throws_an_exception_when_keys_are_not_specified(): void
+    {
+        $this->expectExceptionObject(MapException::keysRequired());
+
+        new ImmutableFloatMap([1.3]);
+    }
+
+    public function test_map_constructor_does_not_throw_any_exception_when_keys_are_specified(): void
+    {
+        $test = new ImmutableFloatMap(['valid' => 0.1]);
+
+        self::assertSame(0.1, $test['valid']);
+    }
+
+    public function test_map_constructor_doest_not_throw_any_exception_when_empty_array_given(): void
+    {
+        $test = new ImmutableFloatMap([]);
+
+        self::assertEmpty((array) $test);
+    }
+}

--- a/tests/Unit/Scalars/ImmutableFloatMapTest.php
+++ b/tests/Unit/Scalars/ImmutableFloatMapTest.php
@@ -33,29 +33,6 @@ final class ImmutableFloatMapTest extends TestCase
         new ImmutableFloatMap($arguments);
     }
 
-    public function providerInvalidScalarInputType(): Generator
-    {
-        yield 'Receiving integers' => [
-            'arguments' => ['key1' => 1, 'key2' => 2],
-        ];
-
-        yield 'Receiving booleans' => [
-            'arguments' => ['key1' => true, 'key2' => false],
-        ];
-
-        yield 'Receiving stdClasses' => [
-            'arguments' => ['key1' => new stdClass(), 'key2' => new stdClass()],
-        ];
-
-        yield 'Receiving strings' => [
-            'arguments' => ['key1' => 'str1', 'key2' => 'str2'],
-        ];
-
-        yield 'Receiving a mix of all scalars' => [
-            'arguments' => ['key1' => true, 'key2' => 1, 'key3' => 2.3, 'key4' => 'string', 'key5' => new stdClass()],
-        ];
-    }
-
     public function test_immutability_of_set(): void
     {
         $test = new ImmutableFloatMap(['key' => 3.14]);
@@ -95,5 +72,28 @@ final class ImmutableFloatMapTest extends TestCase
         $test = new ImmutableFloatMap([]);
 
         self::assertEmpty((array) $test);
+    }
+
+    public function providerInvalidScalarInputType(): Generator
+    {
+        yield 'Receiving integers' => [
+            'arguments' => ['key1' => 1, 'key2' => 2],
+        ];
+
+        yield 'Receiving booleans' => [
+            'arguments' => ['key1' => true, 'key2' => false],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => ['key1' => new stdClass(), 'key2' => new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['key1' => 'str1', 'key2' => 'str2'],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => ['key1' => true, 'key2' => 1, 'key3' => 2.3, 'key4' => 'string', 'key5' => new stdClass()],
+        ];
     }
 }

--- a/tests/Unit/Scalars/ImmutableIntegerArrayTest.php
+++ b/tests/Unit/Scalars/ImmutableIntegerArrayTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Scalars;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypedArrays\AbstractTypedArray;
+use TypedArrays\Exceptions\ImmutabilityException;
+use TypedArrays\Exceptions\InvalidTypeException;
+use TypedArrays\Scalars\ImmutableIntegerArray;
+
+final class ImmutableIntegerArrayTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $test = new ImmutableIntegerArray([1]);
+
+        self::assertInstanceOf(ImmutableIntegerArray::class, $test);
+        self::assertInstanceOf(AbstractTypedArray::class, $test);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputType
+     */
+    public function testInvalidScalarInputType(array $arguments): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        new ImmutableIntegerArray($arguments);
+    }
+
+    public function providerInvalidScalarInputType(): Generator
+    {
+        yield 'Receiving floats' => [
+            'arguments' => [1.23, 4.56],
+        ];
+
+        yield 'Receiving booleans' => [
+            'arguments' => [true, false],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => [new stdClass(), new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['str1', 'str2'],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => [true, 1, 2.3, 'string', new stdClass()],
+        ];
+    }
+
+    public function testImmutabilityOfSet(): void
+    {
+        $test = new ImmutableIntegerArray([1337]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        $test[] = 46;
+    }
+
+    public function testImmutabilityOfUnset(): void
+    {
+        $test = new ImmutableIntegerArray([1984]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        unset($test[0]);
+    }
+}

--- a/tests/Unit/Scalars/ImmutableIntegerArrayTest.php
+++ b/tests/Unit/Scalars/ImmutableIntegerArrayTest.php
@@ -14,7 +14,7 @@ use TypedArrays\Scalars\ImmutableIntegerArray;
 
 final class ImmutableIntegerArrayTest extends TestCase
 {
-    public function testConstruct(): void
+    public function test_construct(): void
     {
         $test = new ImmutableIntegerArray([1]);
 
@@ -25,7 +25,7 @@ final class ImmutableIntegerArrayTest extends TestCase
     /**
      * @dataProvider providerInvalidScalarInputType
      */
-    public function testInvalidScalarInputType(array $arguments): void
+    public function test_invalid_scalar_input_type(array $arguments): void
     {
         $this->expectException(InvalidTypeException::class);
 
@@ -55,7 +55,7 @@ final class ImmutableIntegerArrayTest extends TestCase
         ];
     }
 
-    public function testImmutabilityOfSet(): void
+    public function test_immutability_of_set(): void
     {
         $test = new ImmutableIntegerArray([1337]);
 
@@ -65,7 +65,7 @@ final class ImmutableIntegerArrayTest extends TestCase
         $test[] = 46;
     }
 
-    public function testImmutabilityOfUnset(): void
+    public function test_immutability_of_unset(): void
     {
         $test = new ImmutableIntegerArray([1984]);
 

--- a/tests/Unit/Scalars/ImmutableIntegerArrayTest.php
+++ b/tests/Unit/Scalars/ImmutableIntegerArrayTest.php
@@ -32,6 +32,26 @@ final class ImmutableIntegerArrayTest extends TestCase
         new ImmutableIntegerArray($arguments);
     }
 
+    public function test_immutability_of_set(): void
+    {
+        $test = new ImmutableIntegerArray([1337]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        $test[] = 46;
+    }
+
+    public function test_immutability_of_unset(): void
+    {
+        $test = new ImmutableIntegerArray([1984]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        unset($test[0]);
+    }
+
     public function providerInvalidScalarInputType(): Generator
     {
         yield 'Receiving floats' => [
@@ -53,25 +73,5 @@ final class ImmutableIntegerArrayTest extends TestCase
         yield 'Receiving a mix of all scalars' => [
             'arguments' => [true, 1, 2.3, 'string', new stdClass()],
         ];
-    }
-
-    public function test_immutability_of_set(): void
-    {
-        $test = new ImmutableIntegerArray([1337]);
-
-        $this->expectException(ImmutabilityException::class);
-        $this->expectExceptionMessage('This TypedArray object is immutable.');
-
-        $test[] = 46;
-    }
-
-    public function test_immutability_of_unset(): void
-    {
-        $test = new ImmutableIntegerArray([1984]);
-
-        $this->expectException(ImmutabilityException::class);
-        $this->expectExceptionMessage('This TypedArray object is immutable.');
-
-        unset($test[0]);
     }
 }

--- a/tests/Unit/Scalars/ImmutableIntegerListTest.php
+++ b/tests/Unit/Scalars/ImmutableIntegerListTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Scalars;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypedArrays\AbstractTypedArray;
+use TypedArrays\Exceptions\ImmutabilityException;
+use TypedArrays\Exceptions\InvalidTypeException;
+use TypedArrays\Exceptions\ListException;
+use TypedArrays\Scalars\ImmutableIntegerList;
+
+final class ImmutableIntegerListTest extends TestCase
+{
+    public function test_construct(): void
+    {
+        $test = new ImmutableIntegerList([1]);
+
+        self::assertInstanceOf(ImmutableIntegerList::class, $test);
+        self::assertInstanceOf(AbstractTypedArray::class, $test);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputType
+     */
+    public function test_invalid_scalar_input_type(array $arguments): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        new ImmutableIntegerList($arguments);
+    }
+
+    public function providerInvalidScalarInputType(): Generator
+    {
+        yield 'Receiving floats' => [
+            'arguments' => [1.23, 4.56],
+        ];
+
+        yield 'Receiving booleans' => [
+            'arguments' => [true, false],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => [new stdClass(), new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['str1', 'str2'],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => [true, 1, 2.3, 'string', new stdClass()],
+        ];
+    }
+
+    public function test_immutability_of_set(): void
+    {
+        $test = new ImmutableIntegerList([1337]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        $test[] = 46;
+    }
+
+    public function test_immutability_of_unset(): void
+    {
+        $test = new ImmutableIntegerList([1984]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        unset($test[0]);
+    }
+
+    public function test_list_constructor_throws_an_exception_when_keys_are_specified(): void
+    {
+        $this->expectExceptionObject(ListException::keysNotAllowed());
+
+        new ImmutableIntegerList(['invalid' => 1]);
+    }
+
+    public function test_list_constructor_does_not_throw_any_exception_when_keys_are_not_specified(): void
+    {
+        $test = new ImmutableIntegerList([2]);
+
+        self::assertEquals(2, $test[0]);
+    }
+}

--- a/tests/Unit/Scalars/ImmutableIntegerListTest.php
+++ b/tests/Unit/Scalars/ImmutableIntegerListTest.php
@@ -87,6 +87,6 @@ final class ImmutableIntegerListTest extends TestCase
     {
         $test = new ImmutableIntegerList([2]);
 
-        self::assertEquals(2, $test[0]);
+        self::assertSame(2, $test[0]);
     }
 }

--- a/tests/Unit/Scalars/ImmutableIntegerListTest.php
+++ b/tests/Unit/Scalars/ImmutableIntegerListTest.php
@@ -33,29 +33,6 @@ final class ImmutableIntegerListTest extends TestCase
         new ImmutableIntegerList($arguments);
     }
 
-    public function providerInvalidScalarInputType(): Generator
-    {
-        yield 'Receiving floats' => [
-            'arguments' => [1.23, 4.56],
-        ];
-
-        yield 'Receiving booleans' => [
-            'arguments' => [true, false],
-        ];
-
-        yield 'Receiving stdClasses' => [
-            'arguments' => [new stdClass(), new stdClass()],
-        ];
-
-        yield 'Receiving strings' => [
-            'arguments' => ['str1', 'str2'],
-        ];
-
-        yield 'Receiving a mix of all scalars' => [
-            'arguments' => [true, 1, 2.3, 'string', new stdClass()],
-        ];
-    }
-
     public function test_immutability_of_set(): void
     {
         $test = new ImmutableIntegerList([1337]);
@@ -88,5 +65,28 @@ final class ImmutableIntegerListTest extends TestCase
         $test = new ImmutableIntegerList([2]);
 
         self::assertSame(2, $test[0]);
+    }
+
+    public function providerInvalidScalarInputType(): Generator
+    {
+        yield 'Receiving floats' => [
+            'arguments' => [1.23, 4.56],
+        ];
+
+        yield 'Receiving booleans' => [
+            'arguments' => [true, false],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => [new stdClass(), new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['str1', 'str2'],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => [true, 1, 2.3, 'string', new stdClass()],
+        ];
     }
 }

--- a/tests/Unit/Scalars/ImmutableIntegerMapTest.php
+++ b/tests/Unit/Scalars/ImmutableIntegerMapTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Scalars;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypedArrays\AbstractTypedArray;
+use TypedArrays\Exceptions\ImmutabilityException;
+use TypedArrays\Exceptions\InvalidTypeException;
+use TypedArrays\Exceptions\MapException;
+use TypedArrays\Scalars\ImmutableIntegerMap;
+
+final class ImmutableIntegerMapTest extends TestCase
+{
+    public function test_construct(): void
+    {
+        $test = new ImmutableIntegerMap(['key' => 1]);
+
+        self::assertInstanceOf(ImmutableIntegerMap::class, $test);
+        self::assertInstanceOf(AbstractTypedArray::class, $test);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputType
+     */
+    public function test_invalid_scalar_input_type(array $arguments): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        new ImmutableIntegerMap($arguments);
+    }
+
+    public function providerInvalidScalarInputType(): Generator
+    {
+        yield 'Receiving floats' => [
+            'arguments' => ['key1' => 1.23, 'key2' => 4.56],
+        ];
+
+        yield 'Receiving booleans' => [
+            'arguments' => ['key1' => true, 'key2' => false],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => ['key1' => new stdClass(), 'key2' => new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['key1' => 'str1', 'key2' => 'str2'],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => ['key1' => true, 'key2' => 1, 'key3' => 2.3, 'key4' => 'string', 'key5' => new stdClass()],
+        ];
+    }
+
+    public function test_immutability_of_set(): void
+    {
+        $test = new ImmutableIntegerMap(['key' => 1337]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        $test['invalid'] = 46;
+    }
+
+    public function test_immutability_of_unset(): void
+    {
+        $test = new ImmutableIntegerMap(['key' => 1984]);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        unset($test['key']);
+    }
+
+    public function test_map_constructor_throws_an_exception_when_keys_are_not_specified(): void
+    {
+        $this->expectExceptionObject(MapException::keysRequired());
+
+        new ImmutableIntegerMap([13]);
+    }
+
+    public function test_map_constructor_does_not_throw_any_exception_when_keys_are_specified(): void
+    {
+        $test = new ImmutableIntegerMap(['valid' => 3]);
+
+        self::assertSame(3, $test['valid']);
+    }
+
+    public function test_map_constructor_doest_not_throw_any_exception_when_empty_array_given(): void
+    {
+        $test = new ImmutableIntegerMap([]);
+
+        self::assertEmpty((array) $test);
+    }
+}

--- a/tests/Unit/Scalars/ImmutableIntegerMapTest.php
+++ b/tests/Unit/Scalars/ImmutableIntegerMapTest.php
@@ -33,29 +33,6 @@ final class ImmutableIntegerMapTest extends TestCase
         new ImmutableIntegerMap($arguments);
     }
 
-    public function providerInvalidScalarInputType(): Generator
-    {
-        yield 'Receiving floats' => [
-            'arguments' => ['key1' => 1.23, 'key2' => 4.56],
-        ];
-
-        yield 'Receiving booleans' => [
-            'arguments' => ['key1' => true, 'key2' => false],
-        ];
-
-        yield 'Receiving stdClasses' => [
-            'arguments' => ['key1' => new stdClass(), 'key2' => new stdClass()],
-        ];
-
-        yield 'Receiving strings' => [
-            'arguments' => ['key1' => 'str1', 'key2' => 'str2'],
-        ];
-
-        yield 'Receiving a mix of all scalars' => [
-            'arguments' => ['key1' => true, 'key2' => 1, 'key3' => 2.3, 'key4' => 'string', 'key5' => new stdClass()],
-        ];
-    }
-
     public function test_immutability_of_set(): void
     {
         $test = new ImmutableIntegerMap(['key' => 1337]);
@@ -95,5 +72,28 @@ final class ImmutableIntegerMapTest extends TestCase
         $test = new ImmutableIntegerMap([]);
 
         self::assertEmpty((array) $test);
+    }
+
+    public function providerInvalidScalarInputType(): Generator
+    {
+        yield 'Receiving floats' => [
+            'arguments' => ['key1' => 1.23, 'key2' => 4.56],
+        ];
+
+        yield 'Receiving booleans' => [
+            'arguments' => ['key1' => true, 'key2' => false],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => ['key1' => new stdClass(), 'key2' => new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['key1' => 'str1', 'key2' => 'str2'],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => ['key1' => true, 'key2' => 1, 'key3' => 2.3, 'key4' => 'string', 'key5' => new stdClass()],
+        ];
     }
 }

--- a/tests/Unit/Scalars/ImmutableStringArrayTest.php
+++ b/tests/Unit/Scalars/ImmutableStringArrayTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Scalars;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypedArrays\AbstractTypedArray;
+use TypedArrays\Exceptions\ImmutabilityException;
+use TypedArrays\Exceptions\InvalidTypeException;
+use TypedArrays\Scalars\ImmutableStringArray;
+
+final class ImmutableStringArrayTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $test = new ImmutableStringArray(['test']);
+
+        self::assertInstanceOf(ImmutableStringArray::class, $test);
+        self::assertInstanceOf(AbstractTypedArray::class, $test);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputType
+     */
+    public function testInvalidScalarInputType(array $arguments): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        new ImmutableStringArray($arguments);
+    }
+
+    public function providerInvalidScalarInputType(): Generator
+    {
+        yield 'Receiving integers' => [
+            'arguments' => [1, 2],
+        ];
+
+        yield 'Receiving floats' => [
+            'arguments' => [1.23, 4.56],
+        ];
+
+        yield 'Receiving booleans' => [
+            'arguments' => [true, false],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => [new stdClass(), new stdClass()],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => [true, 1, 2.3, 'string', new stdClass()],
+        ];
+    }
+
+    public function testImmutabilityOfSet(): void
+    {
+        $test = new ImmutableStringArray(['test']);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        $test[] = 'invalid';
+    }
+
+    public function testImmutabilityOfUnset(): void
+    {
+        $test = new ImmutableStringArray(['test']);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        unset($test[0]);
+    }
+}

--- a/tests/Unit/Scalars/ImmutableStringArrayTest.php
+++ b/tests/Unit/Scalars/ImmutableStringArrayTest.php
@@ -14,7 +14,7 @@ use TypedArrays\Scalars\ImmutableStringArray;
 
 final class ImmutableStringArrayTest extends TestCase
 {
-    public function testConstruct(): void
+    public function test_construct(): void
     {
         $test = new ImmutableStringArray(['test']);
 
@@ -25,7 +25,7 @@ final class ImmutableStringArrayTest extends TestCase
     /**
      * @dataProvider providerInvalidScalarInputType
      */
-    public function testInvalidScalarInputType(array $arguments): void
+    public function test_invalid_scalar_input_type(array $arguments): void
     {
         $this->expectException(InvalidTypeException::class);
 
@@ -55,7 +55,7 @@ final class ImmutableStringArrayTest extends TestCase
         ];
     }
 
-    public function testImmutabilityOfSet(): void
+    public function test_immutability_of_set(): void
     {
         $test = new ImmutableStringArray(['test']);
 
@@ -65,7 +65,7 @@ final class ImmutableStringArrayTest extends TestCase
         $test[] = 'invalid';
     }
 
-    public function testImmutabilityOfUnset(): void
+    public function test_immutability_of_unset(): void
     {
         $test = new ImmutableStringArray(['test']);
 

--- a/tests/Unit/Scalars/ImmutableStringArrayTest.php
+++ b/tests/Unit/Scalars/ImmutableStringArrayTest.php
@@ -32,6 +32,26 @@ final class ImmutableStringArrayTest extends TestCase
         new ImmutableStringArray($arguments);
     }
 
+    public function test_immutability_of_set(): void
+    {
+        $test = new ImmutableStringArray(['test']);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        $test[] = 'invalid';
+    }
+
+    public function test_immutability_of_unset(): void
+    {
+        $test = new ImmutableStringArray(['test']);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        unset($test[0]);
+    }
+
     public function providerInvalidScalarInputType(): Generator
     {
         yield 'Receiving integers' => [
@@ -53,25 +73,5 @@ final class ImmutableStringArrayTest extends TestCase
         yield 'Receiving a mix of all scalars' => [
             'arguments' => [true, 1, 2.3, 'string', new stdClass()],
         ];
-    }
-
-    public function test_immutability_of_set(): void
-    {
-        $test = new ImmutableStringArray(['test']);
-
-        $this->expectException(ImmutabilityException::class);
-        $this->expectExceptionMessage('This TypedArray object is immutable.');
-
-        $test[] = 'invalid';
-    }
-
-    public function test_immutability_of_unset(): void
-    {
-        $test = new ImmutableStringArray(['test']);
-
-        $this->expectException(ImmutabilityException::class);
-        $this->expectExceptionMessage('This TypedArray object is immutable.');
-
-        unset($test[0]);
     }
 }

--- a/tests/Unit/Scalars/ImmutableStringListTest.php
+++ b/tests/Unit/Scalars/ImmutableStringListTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Scalars;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypedArrays\AbstractTypedArray;
+use TypedArrays\Exceptions\ImmutabilityException;
+use TypedArrays\Exceptions\InvalidTypeException;
+use TypedArrays\Exceptions\ListException;
+use TypedArrays\Scalars\ImmutableStringList;
+
+final class ImmutableStringListTest extends TestCase
+{
+    public function test_construct(): void
+    {
+        $test = new ImmutableStringList(['test']);
+
+        self::assertInstanceOf(ImmutableStringList::class, $test);
+        self::assertInstanceOf(AbstractTypedArray::class, $test);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputType
+     */
+    public function test_invalid_scalar_input_type(array $arguments): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        new ImmutableStringList($arguments);
+    }
+
+    public function providerInvalidScalarInputType(): Generator
+    {
+        yield 'Receiving integers' => [
+            'arguments' => [1, 2],
+        ];
+
+        yield 'Receiving floats' => [
+            'arguments' => [1.23, 4.56],
+        ];
+
+        yield 'Receiving booleans' => [
+            'arguments' => [true, false],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => [new stdClass(), new stdClass()],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => [true, 1, 2.3, 'string', new stdClass()],
+        ];
+    }
+
+    public function test_immutability_of_set(): void
+    {
+        $test = new ImmutableStringList(['test']);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        $test[] = 'invalid';
+    }
+
+    public function test_immutability_of_unset(): void
+    {
+        $test = new ImmutableStringList(['test']);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        unset($test[0]);
+    }
+
+    public function test_list_constructor_throws_an_exception_when_keys_are_specified(): void
+    {
+        $this->expectExceptionObject(ListException::keysNotAllowed());
+
+        new ImmutableStringList(['invalid' => 'test']);
+    }
+
+    public function test_list_constructor_does_not_throw_any_exception_when_keys_are_not_specified(): void
+    {
+        $test = new ImmutableStringList(['test']);
+
+        self::assertEquals('test', $test[0]);
+    }
+}

--- a/tests/Unit/Scalars/ImmutableStringListTest.php
+++ b/tests/Unit/Scalars/ImmutableStringListTest.php
@@ -87,6 +87,6 @@ final class ImmutableStringListTest extends TestCase
     {
         $test = new ImmutableStringList(['test']);
 
-        self::assertEquals('test', $test[0]);
+        self::assertSame('test', $test[0]);
     }
 }

--- a/tests/Unit/Scalars/ImmutableStringListTest.php
+++ b/tests/Unit/Scalars/ImmutableStringListTest.php
@@ -33,29 +33,6 @@ final class ImmutableStringListTest extends TestCase
         new ImmutableStringList($arguments);
     }
 
-    public function providerInvalidScalarInputType(): Generator
-    {
-        yield 'Receiving integers' => [
-            'arguments' => [1, 2],
-        ];
-
-        yield 'Receiving floats' => [
-            'arguments' => [1.23, 4.56],
-        ];
-
-        yield 'Receiving booleans' => [
-            'arguments' => [true, false],
-        ];
-
-        yield 'Receiving stdClasses' => [
-            'arguments' => [new stdClass(), new stdClass()],
-        ];
-
-        yield 'Receiving a mix of all scalars' => [
-            'arguments' => [true, 1, 2.3, 'string', new stdClass()],
-        ];
-    }
-
     public function test_immutability_of_set(): void
     {
         $test = new ImmutableStringList(['test']);
@@ -88,5 +65,28 @@ final class ImmutableStringListTest extends TestCase
         $test = new ImmutableStringList(['test']);
 
         self::assertSame('test', $test[0]);
+    }
+
+    public function providerInvalidScalarInputType(): Generator
+    {
+        yield 'Receiving integers' => [
+            'arguments' => [1, 2],
+        ];
+
+        yield 'Receiving floats' => [
+            'arguments' => [1.23, 4.56],
+        ];
+
+        yield 'Receiving booleans' => [
+            'arguments' => [true, false],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => [new stdClass(), new stdClass()],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => [true, 1, 2.3, 'string', new stdClass()],
+        ];
     }
 }

--- a/tests/Unit/Scalars/ImmutableStringMapTest.php
+++ b/tests/Unit/Scalars/ImmutableStringMapTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Scalars;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypedArrays\AbstractTypedArray;
+use TypedArrays\Exceptions\ImmutabilityException;
+use TypedArrays\Exceptions\InvalidTypeException;
+use TypedArrays\Exceptions\MapException;
+use TypedArrays\Scalars\ImmutableStringMap;
+
+final class ImmutableStringMapTest extends TestCase
+{
+    public function test_construct(): void
+    {
+        $test = new ImmutableStringMap(['key' => 'test']);
+
+        self::assertInstanceOf(ImmutableStringMap::class, $test);
+        self::assertInstanceOf(AbstractTypedArray::class, $test);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputType
+     */
+    public function test_invalid_scalar_input_type(array $arguments): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        new ImmutableStringMap($arguments);
+    }
+
+    public function providerInvalidScalarInputType(): Generator
+    {
+        yield 'Receiving integers' => [
+            'arguments' => ['key1' => 1, 'key2' => 2],
+        ];
+
+        yield 'Receiving floats' => [
+            'arguments' => ['key1' => 1.23, 'key2' => 4.56],
+        ];
+
+        yield 'Receiving booleans' => [
+            'arguments' => ['key1' => true, 'key2' => false],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => ['key1' => new stdClass(), 'key2' => new stdClass()],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => ['key1' => true, 'key2' => 1, 'key3' => 2.3, 'key4' => 'string', 'key5' => new stdClass()],
+        ];
+    }
+
+    public function test_immutability_of_set(): void
+    {
+        $test = new ImmutableStringMap(['key' => 'test']);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        $test['invalid'] = 'invalid';
+    }
+
+    public function test_immutability_of_unset(): void
+    {
+        $test = new ImmutableStringMap(['key' => 'test']);
+
+        $this->expectException(ImmutabilityException::class);
+        $this->expectExceptionMessage('This TypedArray object is immutable.');
+
+        unset($test['key']);
+    }
+
+    public function test_map_constructor_throws_an_exception_when_keys_are_not_specified(): void
+    {
+        $this->expectExceptionObject(MapException::keysRequired());
+
+        new ImmutableStringMap(['invalid']);
+    }
+
+    public function test_map_constructor_does_not_throw_any_exception_when_keys_are_specified(): void
+    {
+        $test = new ImmutableStringMap(['valid' => 'test']);
+
+        self::assertSame('test', $test['valid']);
+    }
+
+    public function test_map_constructor_doest_not_throw_any_exception_when_empty_array_given(): void
+    {
+        $test = new ImmutableStringMap([]);
+
+        self::assertEmpty((array) $test);
+    }
+}

--- a/tests/Unit/Scalars/ImmutableStringMapTest.php
+++ b/tests/Unit/Scalars/ImmutableStringMapTest.php
@@ -33,29 +33,6 @@ final class ImmutableStringMapTest extends TestCase
         new ImmutableStringMap($arguments);
     }
 
-    public function providerInvalidScalarInputType(): Generator
-    {
-        yield 'Receiving integers' => [
-            'arguments' => ['key1' => 1, 'key2' => 2],
-        ];
-
-        yield 'Receiving floats' => [
-            'arguments' => ['key1' => 1.23, 'key2' => 4.56],
-        ];
-
-        yield 'Receiving booleans' => [
-            'arguments' => ['key1' => true, 'key2' => false],
-        ];
-
-        yield 'Receiving stdClasses' => [
-            'arguments' => ['key1' => new stdClass(), 'key2' => new stdClass()],
-        ];
-
-        yield 'Receiving a mix of all scalars' => [
-            'arguments' => ['key1' => true, 'key2' => 1, 'key3' => 2.3, 'key4' => 'string', 'key5' => new stdClass()],
-        ];
-    }
-
     public function test_immutability_of_set(): void
     {
         $test = new ImmutableStringMap(['key' => 'test']);
@@ -95,5 +72,28 @@ final class ImmutableStringMapTest extends TestCase
         $test = new ImmutableStringMap([]);
 
         self::assertEmpty((array) $test);
+    }
+
+    public function providerInvalidScalarInputType(): Generator
+    {
+        yield 'Receiving integers' => [
+            'arguments' => ['key1' => 1, 'key2' => 2],
+        ];
+
+        yield 'Receiving floats' => [
+            'arguments' => ['key1' => 1.23, 'key2' => 4.56],
+        ];
+
+        yield 'Receiving booleans' => [
+            'arguments' => ['key1' => true, 'key2' => false],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => ['key1' => new stdClass(), 'key2' => new stdClass()],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => ['key1' => true, 'key2' => 1, 'key3' => 2.3, 'key4' => 'string', 'key5' => new stdClass()],
+        ];
     }
 }

--- a/tests/Unit/Scalars/MutableBooleanArrayTest.php
+++ b/tests/Unit/Scalars/MutableBooleanArrayTest.php
@@ -9,15 +9,15 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 use TypedArrays\AbstractTypedArray;
 use TypedArrays\Exceptions\InvalidTypeException;
-use TypedArrays\Scalars\TypedArrayString;
+use TypedArrays\Scalars\MutableBooleanArray;
 
-final class TypedArrayStringTest extends TestCase
+final class MutableBooleanArrayTest extends TestCase
 {
     public function testConstruct(): void
     {
-        $test = new TypedArrayString(['test']);
+        $test = new MutableBooleanArray([true]);
 
-        self::assertInstanceOf(TypedArrayString::class, $test);
+        self::assertInstanceOf(MutableBooleanArray::class, $test);
         self::assertInstanceOf(AbstractTypedArray::class, $test);
     }
 
@@ -28,7 +28,7 @@ final class TypedArrayStringTest extends TestCase
     {
         $this->expectException(InvalidTypeException::class);
 
-        new TypedArrayString($arguments);
+        new MutableBooleanArray($arguments);
     }
 
     /**
@@ -40,7 +40,7 @@ final class TypedArrayStringTest extends TestCase
     {
         $this->expectException(InvalidTypeException::class);
 
-        $test = new TypedArrayString([]);
+        $test = new MutableBooleanArray([]);
         $test[] = $argument;
     }
 
@@ -54,12 +54,12 @@ final class TypedArrayStringTest extends TestCase
             'arguments' => [1.23, 4.56],
         ];
 
-        yield 'Receiving booleans' => [
-            'arguments' => [true, false],
-        ];
-
         yield 'Receiving stdClasses' => [
             'arguments' => [new stdClass(), new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['str1', 'str2'],
         ];
 
         yield 'Receiving a mix of all scalars' => [
@@ -77,12 +77,12 @@ final class TypedArrayStringTest extends TestCase
             'argument' => 1.23,
         ];
 
-        yield 'Adding boolean' => [
-            'argument' => true,
-        ];
-
         yield 'Adding stdClass' => [
             'argument' => new stdClass(),
+        ];
+
+        yield 'Adding string' => [
+            'argument' => 'str1',
         ];
     }
 }

--- a/tests/Unit/Scalars/MutableBooleanArrayTest.php
+++ b/tests/Unit/Scalars/MutableBooleanArrayTest.php
@@ -13,7 +13,7 @@ use TypedArrays\Scalars\MutableBooleanArray;
 
 final class MutableBooleanArrayTest extends TestCase
 {
-    public function testConstruct(): void
+    public function test_construct(): void
     {
         $test = new MutableBooleanArray([true]);
 
@@ -24,7 +24,7 @@ final class MutableBooleanArrayTest extends TestCase
     /**
      * @dataProvider providerInvalidScalarInputTypeOnInstantiate
      */
-    public function testInvalidScalarInputTypeOnInstantiate(array $arguments): void
+    public function test_invalid_scalar_input_type_on_instantiate(array $arguments): void
     {
         $this->expectException(InvalidTypeException::class);
 
@@ -36,7 +36,7 @@ final class MutableBooleanArrayTest extends TestCase
      *
      * @param mixed $argument
      */
-    public function testInvalidScalarInputTypeOnAdd($argument): void
+    public function test_invalid_scalar_input_type_on_add($argument): void
     {
         $this->expectException(InvalidTypeException::class);
 

--- a/tests/Unit/Scalars/MutableBooleanListTest.php
+++ b/tests/Unit/Scalars/MutableBooleanListTest.php
@@ -98,7 +98,7 @@ final class MutableBooleanListTest extends TestCase
     {
         $test = new MutableBooleanList([true]);
 
-        self::assertSame(true, $test[0]);
+        self::assertTrue($test[0]);
     }
 
     public function test_list_setter_throws_an_exception_when_key_is_specified(): void
@@ -116,7 +116,7 @@ final class MutableBooleanListTest extends TestCase
 
         $test[] = true;
 
-        self::assertSame(true, $test[1]);
+        self::assertTrue($test[1]);
     }
 
     public function test_list_setter_does_not_throw_any_exception_when_an_element_is_modified_by_key(): void
@@ -125,6 +125,6 @@ final class MutableBooleanListTest extends TestCase
 
         $test[0] = true;
 
-        self::assertSame(true, $test[0]);
+        self::assertTrue($test[0]);
     }
 }

--- a/tests/Unit/Scalars/MutableBooleanListTest.php
+++ b/tests/Unit/Scalars/MutableBooleanListTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Scalars;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypedArrays\AbstractTypedArray;
+use TypedArrays\Exceptions\InvalidTypeException;
+use TypedArrays\Exceptions\ListException;
+use TypedArrays\Scalars\MutableBooleanList;
+
+final class MutableBooleanListTest extends TestCase
+{
+    public function test_construct(): void
+    {
+        $test = new MutableBooleanList([true]);
+
+        self::assertInstanceOf(MutableBooleanList::class, $test);
+        self::assertInstanceOf(AbstractTypedArray::class, $test);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputTypeOnInstantiate
+     */
+    public function test_invalid_scalar_input_type_on_instantiate(array $arguments): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        new MutableBooleanList($arguments);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputTypeOnAdd
+     *
+     * @param mixed $argument
+     */
+    public function test_invalid_scalar_input_type_on_add($argument): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        $test = new MutableBooleanList([]);
+        $test[] = $argument;
+    }
+
+    public function providerInvalidScalarInputTypeOnInstantiate(): Generator
+    {
+        yield 'Receiving integers' => [
+            'arguments' => [1, 2],
+        ];
+
+        yield 'Receiving floats' => [
+            'arguments' => [1.23, 4.56],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => [new stdClass(), new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['str1', 'str2'],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => [true, 1, 2.3, 'string', new stdClass()],
+        ];
+    }
+
+    public function providerInvalidScalarInputTypeOnAdd(): Generator
+    {
+        yield 'Adding integer' => [
+            'argument' => 1,
+        ];
+
+        yield 'Adding float' => [
+            'argument' => 1.23,
+        ];
+
+        yield 'Adding stdClass' => [
+            'argument' => new stdClass(),
+        ];
+
+        yield 'Adding string' => [
+            'argument' => 'str1',
+        ];
+    }
+
+    public function test_list_constructor_throws_an_exception_when_keys_are_specified(): void
+    {
+        $this->expectExceptionObject(ListException::keysNotAllowed());
+
+        new MutableBooleanList(['invalid' => false]);
+    }
+
+    public function test_list_constructor_does_not_throw_any_exception_when_keys_are_not_specified(): void
+    {
+        $test = new MutableBooleanList([true]);
+
+        self::assertEquals(true, $test[0]);
+    }
+
+    public function test_list_setter_throws_an_exception_when_key_is_specified(): void
+    {
+        $test = new MutableBooleanList([true]);
+
+        $this->expectExceptionObject(ListException::keysNotAllowed());
+
+        $test['invalid'] = false;
+    }
+
+    public function test_list_setter_does_not_throw_any_exception_when_key_is_not_specified(): void
+    {
+        $test = new MutableBooleanList([false]);
+
+        $test[] = true;
+
+        self::assertEquals(true, $test[1]);
+    }
+
+    public function test_list_setter_does_not_throw_any_exception_when_an_element_is_modified_by_key(): void
+    {
+        $test = new MutableBooleanList([false]);
+
+        $test[0] = true;
+
+        self::assertEquals(true, $test[0]);
+    }
+}

--- a/tests/Unit/Scalars/MutableBooleanListTest.php
+++ b/tests/Unit/Scalars/MutableBooleanListTest.php
@@ -45,6 +45,47 @@ final class MutableBooleanListTest extends TestCase
         $test[] = $argument;
     }
 
+    public function test_list_constructor_throws_an_exception_when_keys_are_specified(): void
+    {
+        $this->expectExceptionObject(ListException::keysNotAllowed());
+
+        new MutableBooleanList(['invalid' => false]);
+    }
+
+    public function test_list_constructor_does_not_throw_any_exception_when_keys_are_not_specified(): void
+    {
+        $test = new MutableBooleanList([true]);
+
+        self::assertTrue($test[0]);
+    }
+
+    public function test_list_setter_throws_an_exception_when_key_is_specified(): void
+    {
+        $test = new MutableBooleanList([true]);
+
+        $this->expectExceptionObject(ListException::keysNotAllowed());
+
+        $test['invalid'] = false;
+    }
+
+    public function test_list_setter_does_not_throw_any_exception_when_key_is_not_specified(): void
+    {
+        $test = new MutableBooleanList([false]);
+
+        $test[] = true;
+
+        self::assertTrue($test[1]);
+    }
+
+    public function test_list_setter_does_not_throw_any_exception_when_an_element_is_modified_by_key(): void
+    {
+        $test = new MutableBooleanList([false]);
+
+        $test[0] = true;
+
+        self::assertTrue($test[0]);
+    }
+
     public function providerInvalidScalarInputTypeOnInstantiate(): Generator
     {
         yield 'Receiving integers' => [
@@ -85,46 +126,5 @@ final class MutableBooleanListTest extends TestCase
         yield 'Adding string' => [
             'argument' => 'str1',
         ];
-    }
-
-    public function test_list_constructor_throws_an_exception_when_keys_are_specified(): void
-    {
-        $this->expectExceptionObject(ListException::keysNotAllowed());
-
-        new MutableBooleanList(['invalid' => false]);
-    }
-
-    public function test_list_constructor_does_not_throw_any_exception_when_keys_are_not_specified(): void
-    {
-        $test = new MutableBooleanList([true]);
-
-        self::assertTrue($test[0]);
-    }
-
-    public function test_list_setter_throws_an_exception_when_key_is_specified(): void
-    {
-        $test = new MutableBooleanList([true]);
-
-        $this->expectExceptionObject(ListException::keysNotAllowed());
-
-        $test['invalid'] = false;
-    }
-
-    public function test_list_setter_does_not_throw_any_exception_when_key_is_not_specified(): void
-    {
-        $test = new MutableBooleanList([false]);
-
-        $test[] = true;
-
-        self::assertTrue($test[1]);
-    }
-
-    public function test_list_setter_does_not_throw_any_exception_when_an_element_is_modified_by_key(): void
-    {
-        $test = new MutableBooleanList([false]);
-
-        $test[0] = true;
-
-        self::assertTrue($test[0]);
     }
 }

--- a/tests/Unit/Scalars/MutableBooleanListTest.php
+++ b/tests/Unit/Scalars/MutableBooleanListTest.php
@@ -98,7 +98,7 @@ final class MutableBooleanListTest extends TestCase
     {
         $test = new MutableBooleanList([true]);
 
-        self::assertEquals(true, $test[0]);
+        self::assertSame(true, $test[0]);
     }
 
     public function test_list_setter_throws_an_exception_when_key_is_specified(): void
@@ -116,7 +116,7 @@ final class MutableBooleanListTest extends TestCase
 
         $test[] = true;
 
-        self::assertEquals(true, $test[1]);
+        self::assertSame(true, $test[1]);
     }
 
     public function test_list_setter_does_not_throw_any_exception_when_an_element_is_modified_by_key(): void
@@ -125,6 +125,6 @@ final class MutableBooleanListTest extends TestCase
 
         $test[0] = true;
 
-        self::assertEquals(true, $test[0]);
+        self::assertSame(true, $test[0]);
     }
 }

--- a/tests/Unit/Scalars/MutableBooleanMapTest.php
+++ b/tests/Unit/Scalars/MutableBooleanMapTest.php
@@ -98,7 +98,7 @@ final class MutableBooleanMapTest extends TestCase
     {
         $test = new MutableBooleanMap(['valid' => true]);
 
-        self::assertSame(true, $test['valid']);
+        self::assertTrue($test['valid']);
     }
 
     public function test_map_constructor_doest_not_throw_any_exception_when_empty_array_given(): void
@@ -123,6 +123,6 @@ final class MutableBooleanMapTest extends TestCase
 
         $test['valid'] = true;
 
-        self::assertSame(true, $test['valid']);
+        self::assertTrue($test['valid']);
     }
 }

--- a/tests/Unit/Scalars/MutableBooleanMapTest.php
+++ b/tests/Unit/Scalars/MutableBooleanMapTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Scalars;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypedArrays\AbstractTypedArray;
+use TypedArrays\Exceptions\InvalidTypeException;
+use TypedArrays\Exceptions\MapException;
+use TypedArrays\Scalars\MutableBooleanMap;
+
+final class MutableBooleanMapTest extends TestCase
+{
+    public function test_construct(): void
+    {
+        $test = new MutableBooleanMap(['key' => true]);
+
+        self::assertInstanceOf(MutableBooleanMap::class, $test);
+        self::assertInstanceOf(AbstractTypedArray::class, $test);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputTypeOnInstantiate
+     */
+    public function test_invalid_scalar_input_type_on_instantiate(array $arguments): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        new MutableBooleanMap($arguments);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputTypeOnAdd
+     *
+     * @param mixed $argument
+     */
+    public function test_invalid_scalar_input_type_on_add($argument): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        $test = new MutableBooleanMap([]);
+        $test['invalid'] = $argument;
+    }
+
+    public function providerInvalidScalarInputTypeOnInstantiate(): Generator
+    {
+        yield 'Receiving integers' => [
+            'arguments' => ['key1' => 1, 'key2' => 2],
+        ];
+
+        yield 'Receiving floats' => [
+            'arguments' => ['key1' => 1.23, 'key2' => 4.56],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => ['key1' => new stdClass(), 'key2' => new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['key1' => 'str1', 'key2' => 'str2'],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => ['key1' => true, 'key2' => 1, 'key3' => 2.3, 'key4' => 'string', 'key5' => new stdClass()],
+        ];
+    }
+
+    public function providerInvalidScalarInputTypeOnAdd(): Generator
+    {
+        yield 'Adding integer' => [
+            'argument' => 1,
+        ];
+
+        yield 'Adding float' => [
+            'argument' => 1.23,
+        ];
+
+        yield 'Adding stdClass' => [
+            'argument' => new stdClass(),
+        ];
+
+        yield 'Adding string' => [
+            'argument' => 'str1',
+        ];
+    }
+
+    public function test_map_constructor_throws_an_exception_when_keys_are_not_specified(): void
+    {
+        $this->expectExceptionObject(MapException::keysRequired());
+
+        new MutableBooleanMap([false]);
+    }
+
+    public function test_map_constructor_does_not_throw_any_exception_when_keys_are_specified(): void
+    {
+        $test = new MutableBooleanMap(['valid' => true]);
+
+        self::assertSame(true, $test['valid']);
+    }
+
+    public function test_map_constructor_doest_not_throw_any_exception_when_empty_array_given(): void
+    {
+        $test = new MutableBooleanMap([]);
+
+        self::assertEmpty((array) $test);
+    }
+
+    public function test_map_setter_throws_an_exception_when_key_is_not_specified(): void
+    {
+        $test = new MutableBooleanMap(['valid' => true]);
+
+        $this->expectExceptionObject(MapException::keysRequired());
+
+        $test[] = false;
+    }
+
+    public function test_map_setter_does_not_throw_any_exception_when_key_is_specified(): void
+    {
+        $test = new MutableBooleanMap(['key' => false]);
+
+        $test['valid'] = true;
+
+        self::assertSame(true, $test['valid']);
+    }
+}

--- a/tests/Unit/Scalars/MutableBooleanMapTest.php
+++ b/tests/Unit/Scalars/MutableBooleanMapTest.php
@@ -45,6 +45,45 @@ final class MutableBooleanMapTest extends TestCase
         $test['invalid'] = $argument;
     }
 
+    public function test_map_constructor_throws_an_exception_when_keys_are_not_specified(): void
+    {
+        $this->expectExceptionObject(MapException::keysRequired());
+
+        new MutableBooleanMap([false]);
+    }
+
+    public function test_map_constructor_does_not_throw_any_exception_when_keys_are_specified(): void
+    {
+        $test = new MutableBooleanMap(['valid' => true]);
+
+        self::assertTrue($test['valid']);
+    }
+
+    public function test_map_constructor_doest_not_throw_any_exception_when_empty_array_given(): void
+    {
+        $test = new MutableBooleanMap([]);
+
+        self::assertEmpty((array) $test);
+    }
+
+    public function test_map_setter_throws_an_exception_when_key_is_not_specified(): void
+    {
+        $test = new MutableBooleanMap(['valid' => true]);
+
+        $this->expectExceptionObject(MapException::keysRequired());
+
+        $test[] = false;
+    }
+
+    public function test_map_setter_does_not_throw_any_exception_when_key_is_specified(): void
+    {
+        $test = new MutableBooleanMap(['key' => false]);
+
+        $test['valid'] = true;
+
+        self::assertTrue($test['valid']);
+    }
+
     public function providerInvalidScalarInputTypeOnInstantiate(): Generator
     {
         yield 'Receiving integers' => [
@@ -85,44 +124,5 @@ final class MutableBooleanMapTest extends TestCase
         yield 'Adding string' => [
             'argument' => 'str1',
         ];
-    }
-
-    public function test_map_constructor_throws_an_exception_when_keys_are_not_specified(): void
-    {
-        $this->expectExceptionObject(MapException::keysRequired());
-
-        new MutableBooleanMap([false]);
-    }
-
-    public function test_map_constructor_does_not_throw_any_exception_when_keys_are_specified(): void
-    {
-        $test = new MutableBooleanMap(['valid' => true]);
-
-        self::assertTrue($test['valid']);
-    }
-
-    public function test_map_constructor_doest_not_throw_any_exception_when_empty_array_given(): void
-    {
-        $test = new MutableBooleanMap([]);
-
-        self::assertEmpty((array) $test);
-    }
-
-    public function test_map_setter_throws_an_exception_when_key_is_not_specified(): void
-    {
-        $test = new MutableBooleanMap(['valid' => true]);
-
-        $this->expectExceptionObject(MapException::keysRequired());
-
-        $test[] = false;
-    }
-
-    public function test_map_setter_does_not_throw_any_exception_when_key_is_specified(): void
-    {
-        $test = new MutableBooleanMap(['key' => false]);
-
-        $test['valid'] = true;
-
-        self::assertTrue($test['valid']);
     }
 }

--- a/tests/Unit/Scalars/MutableFloatArrayTest.php
+++ b/tests/Unit/Scalars/MutableFloatArrayTest.php
@@ -9,15 +9,15 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 use TypedArrays\AbstractTypedArray;
 use TypedArrays\Exceptions\InvalidTypeException;
-use TypedArrays\Scalars\TypedArrayBoolean;
+use TypedArrays\Scalars\MutableFloatArray;
 
-final class TypedArrayBooleanTest extends TestCase
+final class MutableFloatArrayTest extends TestCase
 {
     public function testConstruct(): void
     {
-        $test = new TypedArrayBoolean([true]);
+        $test = new MutableFloatArray([1.5]);
 
-        self::assertInstanceOf(TypedArrayBoolean::class, $test);
+        self::assertInstanceOf(MutableFloatArray::class, $test);
         self::assertInstanceOf(AbstractTypedArray::class, $test);
     }
 
@@ -28,7 +28,7 @@ final class TypedArrayBooleanTest extends TestCase
     {
         $this->expectException(InvalidTypeException::class);
 
-        new TypedArrayBoolean($arguments);
+        new MutableFloatArray($arguments);
     }
 
     /**
@@ -40,7 +40,7 @@ final class TypedArrayBooleanTest extends TestCase
     {
         $this->expectException(InvalidTypeException::class);
 
-        $test = new TypedArrayBoolean([]);
+        $test = new MutableFloatArray([]);
         $test[] = $argument;
     }
 
@@ -50,8 +50,8 @@ final class TypedArrayBooleanTest extends TestCase
             'arguments' => [1, 2],
         ];
 
-        yield 'Receiving floats' => [
-            'arguments' => [1.23, 4.56],
+        yield 'Receiving booleans' => [
+            'arguments' => [true, false],
         ];
 
         yield 'Receiving stdClasses' => [
@@ -73,8 +73,8 @@ final class TypedArrayBooleanTest extends TestCase
             'argument' => 1,
         ];
 
-        yield 'Adding float' => [
-            'argument' => 1.23,
+        yield 'Adding boolean' => [
+            'argument' => true,
         ];
 
         yield 'Adding stdClass' => [

--- a/tests/Unit/Scalars/MutableFloatArrayTest.php
+++ b/tests/Unit/Scalars/MutableFloatArrayTest.php
@@ -13,7 +13,7 @@ use TypedArrays\Scalars\MutableFloatArray;
 
 final class MutableFloatArrayTest extends TestCase
 {
-    public function testConstruct(): void
+    public function test_construct(): void
     {
         $test = new MutableFloatArray([1.5]);
 
@@ -24,7 +24,7 @@ final class MutableFloatArrayTest extends TestCase
     /**
      * @dataProvider providerInvalidScalarInputTypeOnInstantiate
      */
-    public function testInvalidScalarInputTypeOnInstantiate(array $arguments): void
+    public function test_invalid_scalar_input_type_on_instantiate(array $arguments): void
     {
         $this->expectException(InvalidTypeException::class);
 
@@ -36,7 +36,7 @@ final class MutableFloatArrayTest extends TestCase
      *
      * @param mixed $argument
      */
-    public function testInvalidScalarInputTypeOnAdd($argument): void
+    public function test_invalid_scalar_input_type_on_add($argument): void
     {
         $this->expectException(InvalidTypeException::class);
 

--- a/tests/Unit/Scalars/MutableFloatListTest.php
+++ b/tests/Unit/Scalars/MutableFloatListTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Scalars;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypedArrays\AbstractTypedArray;
+use TypedArrays\Exceptions\InvalidTypeException;
+use TypedArrays\Exceptions\ListException;
+use TypedArrays\Scalars\MutableFloatList;
+
+final class MutableFloatListTest extends TestCase
+{
+    public function test_construct(): void
+    {
+        $test = new MutableFloatList([1.5]);
+
+        self::assertInstanceOf(MutableFloatList::class, $test);
+        self::assertInstanceOf(AbstractTypedArray::class, $test);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputTypeOnInstantiate
+     */
+    public function test_invalid_scalar_input_type_on_instantiate(array $arguments): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        new MutableFloatList($arguments);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputTypeOnAdd
+     *
+     * @param mixed $argument
+     */
+    public function test_invalid_scalar_input_type_on_add($argument): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        $test = new MutableFloatList([]);
+        $test[] = $argument;
+    }
+
+    public function providerInvalidScalarInputTypeOnInstantiate(): Generator
+    {
+        yield 'Receiving integers' => [
+            'arguments' => [1, 2],
+        ];
+
+        yield 'Receiving booleans' => [
+            'arguments' => [true, false],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => [new stdClass(), new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['str1', 'str2'],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => [true, 1, 2.3, 'string', new stdClass()],
+        ];
+    }
+
+    public function providerInvalidScalarInputTypeOnAdd(): Generator
+    {
+        yield 'Adding integer' => [
+            'argument' => 1,
+        ];
+
+        yield 'Adding boolean' => [
+            'argument' => true,
+        ];
+
+        yield 'Adding stdClass' => [
+            'argument' => new stdClass(),
+        ];
+
+        yield 'Adding string' => [
+            'argument' => 'str1',
+        ];
+    }
+
+    public function test_list_constructor_throws_an_exception_when_keys_are_specified(): void
+    {
+        $this->expectExceptionObject(ListException::keysNotAllowed());
+
+        new MutableFloatList(['invalid' => 2.718]);
+    }
+
+    public function test_list_constructor_does_not_throw_any_exception_when_keys_are_not_specified(): void
+    {
+        $test = new MutableFloatList([137.5]);
+
+        self::assertEquals(137.5, $test[0]);
+    }
+
+    public function test_list_setter_throws_an_exception_when_key_is_specified(): void
+    {
+        $test = new MutableFloatList([1.4142]);
+
+        $this->expectExceptionObject(ListException::keysNotAllowed());
+
+        $test['invalid'] = 0.42;
+    }
+
+    public function test_list_setter_does_not_throw_any_exception_when_key_is_not_specified(): void
+    {
+        $test = new MutableFloatList([1.2235]);
+
+        $test[] = 8.1321;
+
+        self::assertEquals(8.1321, $test[1]);
+    }
+
+    public function test_list_setter_does_not_throw_any_exception_when_an_element_is_modified_by_key(): void
+    {
+        $test = new MutableFloatList([1.732]);
+
+        $test[0] = 0.508;
+
+        self::assertEquals(0.508, $test[0]);
+    }
+}

--- a/tests/Unit/Scalars/MutableFloatListTest.php
+++ b/tests/Unit/Scalars/MutableFloatListTest.php
@@ -98,7 +98,7 @@ final class MutableFloatListTest extends TestCase
     {
         $test = new MutableFloatList([137.5]);
 
-        self::assertEquals(137.5, $test[0]);
+        self::assertSame(137.5, $test[0]);
     }
 
     public function test_list_setter_throws_an_exception_when_key_is_specified(): void
@@ -116,7 +116,7 @@ final class MutableFloatListTest extends TestCase
 
         $test[] = 8.1321;
 
-        self::assertEquals(8.1321, $test[1]);
+        self::assertSame(8.1321, $test[1]);
     }
 
     public function test_list_setter_does_not_throw_any_exception_when_an_element_is_modified_by_key(): void
@@ -125,6 +125,6 @@ final class MutableFloatListTest extends TestCase
 
         $test[0] = 0.508;
 
-        self::assertEquals(0.508, $test[0]);
+        self::assertSame(0.508, $test[0]);
     }
 }

--- a/tests/Unit/Scalars/MutableFloatListTest.php
+++ b/tests/Unit/Scalars/MutableFloatListTest.php
@@ -45,6 +45,47 @@ final class MutableFloatListTest extends TestCase
         $test[] = $argument;
     }
 
+    public function test_list_constructor_throws_an_exception_when_keys_are_specified(): void
+    {
+        $this->expectExceptionObject(ListException::keysNotAllowed());
+
+        new MutableFloatList(['invalid' => 2.718]);
+    }
+
+    public function test_list_constructor_does_not_throw_any_exception_when_keys_are_not_specified(): void
+    {
+        $test = new MutableFloatList([137.5]);
+
+        self::assertSame(137.5, $test[0]);
+    }
+
+    public function test_list_setter_throws_an_exception_when_key_is_specified(): void
+    {
+        $test = new MutableFloatList([1.4142]);
+
+        $this->expectExceptionObject(ListException::keysNotAllowed());
+
+        $test['invalid'] = 0.42;
+    }
+
+    public function test_list_setter_does_not_throw_any_exception_when_key_is_not_specified(): void
+    {
+        $test = new MutableFloatList([1.2235]);
+
+        $test[] = 8.1321;
+
+        self::assertSame(8.1321, $test[1]);
+    }
+
+    public function test_list_setter_does_not_throw_any_exception_when_an_element_is_modified_by_key(): void
+    {
+        $test = new MutableFloatList([1.732]);
+
+        $test[0] = 0.508;
+
+        self::assertSame(0.508, $test[0]);
+    }
+
     public function providerInvalidScalarInputTypeOnInstantiate(): Generator
     {
         yield 'Receiving integers' => [
@@ -85,46 +126,5 @@ final class MutableFloatListTest extends TestCase
         yield 'Adding string' => [
             'argument' => 'str1',
         ];
-    }
-
-    public function test_list_constructor_throws_an_exception_when_keys_are_specified(): void
-    {
-        $this->expectExceptionObject(ListException::keysNotAllowed());
-
-        new MutableFloatList(['invalid' => 2.718]);
-    }
-
-    public function test_list_constructor_does_not_throw_any_exception_when_keys_are_not_specified(): void
-    {
-        $test = new MutableFloatList([137.5]);
-
-        self::assertSame(137.5, $test[0]);
-    }
-
-    public function test_list_setter_throws_an_exception_when_key_is_specified(): void
-    {
-        $test = new MutableFloatList([1.4142]);
-
-        $this->expectExceptionObject(ListException::keysNotAllowed());
-
-        $test['invalid'] = 0.42;
-    }
-
-    public function test_list_setter_does_not_throw_any_exception_when_key_is_not_specified(): void
-    {
-        $test = new MutableFloatList([1.2235]);
-
-        $test[] = 8.1321;
-
-        self::assertSame(8.1321, $test[1]);
-    }
-
-    public function test_list_setter_does_not_throw_any_exception_when_an_element_is_modified_by_key(): void
-    {
-        $test = new MutableFloatList([1.732]);
-
-        $test[0] = 0.508;
-
-        self::assertSame(0.508, $test[0]);
     }
 }

--- a/tests/Unit/Scalars/MutableFloatMapTest.php
+++ b/tests/Unit/Scalars/MutableFloatMapTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Scalars;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypedArrays\AbstractTypedArray;
+use TypedArrays\Exceptions\InvalidTypeException;
+use TypedArrays\Exceptions\MapException;
+use TypedArrays\Scalars\MutableFloatMap;
+
+final class MutableFloatMapTest extends TestCase
+{
+    public function test_construct(): void
+    {
+        $test = new MutableFloatMap(['key' => 1.5]);
+
+        self::assertInstanceOf(MutableFloatMap::class, $test);
+        self::assertInstanceOf(AbstractTypedArray::class, $test);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputTypeOnInstantiate
+     */
+    public function test_invalid_scalar_input_type_on_instantiate(array $arguments): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        new MutableFloatMap($arguments);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputTypeOnAdd
+     *
+     * @param mixed $argument
+     */
+    public function test_invalid_scalar_input_type_on_add($argument): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        $test = new MutableFloatMap([]);
+        $test['invalid'] = $argument;
+    }
+
+    public function providerInvalidScalarInputTypeOnInstantiate(): Generator
+    {
+        yield 'Receiving integers' => [
+            'arguments' => ['key1' => 1, 'key2' => 2],
+        ];
+
+        yield 'Receiving booleans' => [
+            'arguments' => ['key1' => true, 'key2' => false],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => ['key1' => new stdClass(), 'key2' => new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['key1' => 'str1', 'key2' => 'str2'],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => ['key1' => true, 'key2' => 1, 'key3' => 2.3, 'key4' => 'string', 'key5' => new stdClass()],
+        ];
+    }
+
+    public function providerInvalidScalarInputTypeOnAdd(): Generator
+    {
+        yield 'Adding integer' => [
+            'argument' => 1,
+        ];
+
+        yield 'Adding boolean' => [
+            'argument' => true,
+        ];
+
+        yield 'Adding stdClass' => [
+            'argument' => new stdClass(),
+        ];
+
+        yield 'Adding string' => [
+            'argument' => 'str1',
+        ];
+    }
+
+    public function test_map_constructor_throws_an_exception_when_keys_are_not_specified(): void
+    {
+        $this->expectExceptionObject(MapException::keysRequired());
+
+        new MutableFloatMap([1.3]);
+    }
+
+    public function test_map_constructor_does_not_throw_any_exception_when_keys_are_specified(): void
+    {
+        $test = new MutableFloatMap(['valid' => 0.1]);
+
+        self::assertSame(0.1, $test['valid']);
+    }
+
+    public function test_map_constructor_doest_not_throw_any_exception_when_empty_array_given(): void
+    {
+        $test = new MutableFloatMap([]);
+
+        self::assertEmpty((array) $test);
+    }
+
+    public function test_map_setter_throws_an_exception_when_key_is_not_specified(): void
+    {
+        $test = new MutableFloatMap(['valid' => 4.1]);
+
+        $this->expectExceptionObject(MapException::keysRequired());
+
+        $test[] = 4.2;
+    }
+
+    public function test_map_setter_does_not_throw_any_exception_when_key_is_specified(): void
+    {
+        $test = new MutableFloatMap(['key' => 1.3]);
+
+        $test['valid'] = 5.6;
+
+        self::assertSame(5.6, $test['valid']);
+    }
+}

--- a/tests/Unit/Scalars/MutableFloatMapTest.php
+++ b/tests/Unit/Scalars/MutableFloatMapTest.php
@@ -45,6 +45,45 @@ final class MutableFloatMapTest extends TestCase
         $test['invalid'] = $argument;
     }
 
+    public function test_map_constructor_throws_an_exception_when_keys_are_not_specified(): void
+    {
+        $this->expectExceptionObject(MapException::keysRequired());
+
+        new MutableFloatMap([1.3]);
+    }
+
+    public function test_map_constructor_does_not_throw_any_exception_when_keys_are_specified(): void
+    {
+        $test = new MutableFloatMap(['valid' => 0.1]);
+
+        self::assertSame(0.1, $test['valid']);
+    }
+
+    public function test_map_constructor_doest_not_throw_any_exception_when_empty_array_given(): void
+    {
+        $test = new MutableFloatMap([]);
+
+        self::assertEmpty((array) $test);
+    }
+
+    public function test_map_setter_throws_an_exception_when_key_is_not_specified(): void
+    {
+        $test = new MutableFloatMap(['valid' => 4.1]);
+
+        $this->expectExceptionObject(MapException::keysRequired());
+
+        $test[] = 4.2;
+    }
+
+    public function test_map_setter_does_not_throw_any_exception_when_key_is_specified(): void
+    {
+        $test = new MutableFloatMap(['key' => 1.3]);
+
+        $test['valid'] = 5.6;
+
+        self::assertSame(5.6, $test['valid']);
+    }
+
     public function providerInvalidScalarInputTypeOnInstantiate(): Generator
     {
         yield 'Receiving integers' => [
@@ -85,44 +124,5 @@ final class MutableFloatMapTest extends TestCase
         yield 'Adding string' => [
             'argument' => 'str1',
         ];
-    }
-
-    public function test_map_constructor_throws_an_exception_when_keys_are_not_specified(): void
-    {
-        $this->expectExceptionObject(MapException::keysRequired());
-
-        new MutableFloatMap([1.3]);
-    }
-
-    public function test_map_constructor_does_not_throw_any_exception_when_keys_are_specified(): void
-    {
-        $test = new MutableFloatMap(['valid' => 0.1]);
-
-        self::assertSame(0.1, $test['valid']);
-    }
-
-    public function test_map_constructor_doest_not_throw_any_exception_when_empty_array_given(): void
-    {
-        $test = new MutableFloatMap([]);
-
-        self::assertEmpty((array) $test);
-    }
-
-    public function test_map_setter_throws_an_exception_when_key_is_not_specified(): void
-    {
-        $test = new MutableFloatMap(['valid' => 4.1]);
-
-        $this->expectExceptionObject(MapException::keysRequired());
-
-        $test[] = 4.2;
-    }
-
-    public function test_map_setter_does_not_throw_any_exception_when_key_is_specified(): void
-    {
-        $test = new MutableFloatMap(['key' => 1.3]);
-
-        $test['valid'] = 5.6;
-
-        self::assertSame(5.6, $test['valid']);
     }
 }

--- a/tests/Unit/Scalars/MutableIntegerArrayTest.php
+++ b/tests/Unit/Scalars/MutableIntegerArrayTest.php
@@ -13,7 +13,7 @@ use TypedArrays\Scalars\MutableIntegerArray;
 
 final class MutableIntegerArrayTest extends TestCase
 {
-    public function testConstruct(): void
+    public function test_construct(): void
     {
         $test = new MutableIntegerArray([1]);
 
@@ -24,7 +24,7 @@ final class MutableIntegerArrayTest extends TestCase
     /**
      * @dataProvider providerInvalidScalarInputTypeOnInstantiate
      */
-    public function testInvalidScalarInputTypeOnInstantiate(array $arguments): void
+    public function test_invalid_scalar_input_type_on_instantiate(array $arguments): void
     {
         $this->expectException(InvalidTypeException::class);
 
@@ -36,7 +36,7 @@ final class MutableIntegerArrayTest extends TestCase
      *
      * @param mixed $argument
      */
-    public function testInvalidScalarInputTypeOnAdd($argument): void
+    public function test_invalid_scalar_input_type_on_add($argument): void
     {
         $this->expectException(InvalidTypeException::class);
 

--- a/tests/Unit/Scalars/MutableIntegerArrayTest.php
+++ b/tests/Unit/Scalars/MutableIntegerArrayTest.php
@@ -9,15 +9,15 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 use TypedArrays\AbstractTypedArray;
 use TypedArrays\Exceptions\InvalidTypeException;
-use TypedArrays\Scalars\TypedArrayFloat;
+use TypedArrays\Scalars\MutableIntegerArray;
 
-final class TypedArrayFloatTest extends TestCase
+final class MutableIntegerArrayTest extends TestCase
 {
     public function testConstruct(): void
     {
-        $test = new TypedArrayFloat([1.5]);
+        $test = new MutableIntegerArray([1]);
 
-        self::assertInstanceOf(TypedArrayFloat::class, $test);
+        self::assertInstanceOf(MutableIntegerArray::class, $test);
         self::assertInstanceOf(AbstractTypedArray::class, $test);
     }
 
@@ -28,7 +28,7 @@ final class TypedArrayFloatTest extends TestCase
     {
         $this->expectException(InvalidTypeException::class);
 
-        new TypedArrayFloat($arguments);
+        new MutableIntegerArray($arguments);
     }
 
     /**
@@ -40,14 +40,14 @@ final class TypedArrayFloatTest extends TestCase
     {
         $this->expectException(InvalidTypeException::class);
 
-        $test = new TypedArrayFloat([]);
+        $test = new MutableIntegerArray([]);
         $test[] = $argument;
     }
 
     public function providerInvalidScalarInputTypeOnInstantiate(): Generator
     {
-        yield 'Receiving integers' => [
-            'arguments' => [1, 2],
+        yield 'Receiving floats' => [
+            'arguments' => [1.23, 4.56],
         ];
 
         yield 'Receiving booleans' => [
@@ -69,8 +69,8 @@ final class TypedArrayFloatTest extends TestCase
 
     public function providerInvalidScalarInputTypeOnAdd(): Generator
     {
-        yield 'Adding integer' => [
-            'argument' => 1,
+        yield 'Adding float' => [
+            'argument' => 1.23,
         ];
 
         yield 'Adding boolean' => [

--- a/tests/Unit/Scalars/MutableIntegerListTest.php
+++ b/tests/Unit/Scalars/MutableIntegerListTest.php
@@ -45,6 +45,47 @@ final class MutableIntegerListTest extends TestCase
         $test[] = $argument;
     }
 
+    public function test_list_constructor_throws_an_exception_when_keys_are_specified(): void
+    {
+        $this->expectExceptionObject(ListException::keysNotAllowed());
+
+        new MutableIntegerList(['invalid' => 1]);
+    }
+
+    public function test_list_constructor_does_not_throw_any_exception_when_keys_are_not_specified(): void
+    {
+        $test = new MutableIntegerList([2]);
+
+        self::assertSame(2, $test[0]);
+    }
+
+    public function test_list_setter_throws_an_exception_when_key_is_specified(): void
+    {
+        $test = new MutableIntegerList([3]);
+
+        $this->expectExceptionObject(ListException::keysNotAllowed());
+
+        $test['invalid'] = 5;
+    }
+
+    public function test_list_setter_does_not_throw_any_exception_when_key_is_not_specified(): void
+    {
+        $test = new MutableIntegerList([8]);
+
+        $test[] = 13;
+
+        self::assertSame(13, $test[1]);
+    }
+
+    public function test_list_setter_does_not_throw_any_exception_when_an_element_is_modified_by_key(): void
+    {
+        $test = new MutableIntegerList([21]);
+
+        $test[0] = 34;
+
+        self::assertSame(34, $test[0]);
+    }
+
     public function providerInvalidScalarInputTypeOnInstantiate(): Generator
     {
         yield 'Receiving floats' => [
@@ -85,46 +126,5 @@ final class MutableIntegerListTest extends TestCase
         yield 'Adding string' => [
             'argument' => 'str1',
         ];
-    }
-
-    public function test_list_constructor_throws_an_exception_when_keys_are_specified(): void
-    {
-        $this->expectExceptionObject(ListException::keysNotAllowed());
-
-        new MutableIntegerList(['invalid' => 1]);
-    }
-
-    public function test_list_constructor_does_not_throw_any_exception_when_keys_are_not_specified(): void
-    {
-        $test = new MutableIntegerList([2]);
-
-        self::assertSame(2, $test[0]);
-    }
-
-    public function test_list_setter_throws_an_exception_when_key_is_specified(): void
-    {
-        $test = new MutableIntegerList([3]);
-
-        $this->expectExceptionObject(ListException::keysNotAllowed());
-
-        $test['invalid'] = 5;
-    }
-
-    public function test_list_setter_does_not_throw_any_exception_when_key_is_not_specified(): void
-    {
-        $test = new MutableIntegerList([8]);
-
-        $test[] = 13;
-
-        self::assertSame(13, $test[1]);
-    }
-
-    public function test_list_setter_does_not_throw_any_exception_when_an_element_is_modified_by_key(): void
-    {
-        $test = new MutableIntegerList([21]);
-
-        $test[0] = 34;
-
-        self::assertSame(34, $test[0]);
     }
 }

--- a/tests/Unit/Scalars/MutableIntegerListTest.php
+++ b/tests/Unit/Scalars/MutableIntegerListTest.php
@@ -98,7 +98,7 @@ final class MutableIntegerListTest extends TestCase
     {
         $test = new MutableIntegerList([2]);
 
-        self::assertEquals(2, $test[0]);
+        self::assertSame(2, $test[0]);
     }
 
     public function test_list_setter_throws_an_exception_when_key_is_specified(): void
@@ -116,7 +116,7 @@ final class MutableIntegerListTest extends TestCase
 
         $test[] = 13;
 
-        self::assertEquals(13, $test[1]);
+        self::assertSame(13, $test[1]);
     }
 
     public function test_list_setter_does_not_throw_any_exception_when_an_element_is_modified_by_key(): void
@@ -125,6 +125,6 @@ final class MutableIntegerListTest extends TestCase
 
         $test[0] = 34;
 
-        self::assertEquals(34, $test[0]);
+        self::assertSame(34, $test[0]);
     }
 }

--- a/tests/Unit/Scalars/MutableIntegerListTest.php
+++ b/tests/Unit/Scalars/MutableIntegerListTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Scalars;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypedArrays\AbstractTypedArray;
+use TypedArrays\Exceptions\InvalidTypeException;
+use TypedArrays\Exceptions\ListException;
+use TypedArrays\Scalars\MutableIntegerList;
+
+final class MutableIntegerListTest extends TestCase
+{
+    public function test_construct(): void
+    {
+        $test = new MutableIntegerList([1]);
+
+        self::assertInstanceOf(MutableIntegerList::class, $test);
+        self::assertInstanceOf(AbstractTypedArray::class, $test);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputTypeOnInstantiate
+     */
+    public function test_invalid_scalar_input_type_on_instantiate(array $arguments): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        new MutableIntegerList($arguments);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputTypeOnAdd
+     *
+     * @param mixed $argument
+     */
+    public function test_invalid_scalar_input_type_on_add($argument): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        $test = new MutableIntegerList([]);
+        $test[] = $argument;
+    }
+
+    public function providerInvalidScalarInputTypeOnInstantiate(): Generator
+    {
+        yield 'Receiving floats' => [
+            'arguments' => [1.23, 4.56],
+        ];
+
+        yield 'Receiving booleans' => [
+            'arguments' => [true, false],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => [new stdClass(), new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['str1', 'str2'],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => [true, 1, 2.3, 'string', new stdClass()],
+        ];
+    }
+
+    public function providerInvalidScalarInputTypeOnAdd(): Generator
+    {
+        yield 'Adding float' => [
+            'argument' => 1.23,
+        ];
+
+        yield 'Adding boolean' => [
+            'argument' => true,
+        ];
+
+        yield 'Adding stdClass' => [
+            'argument' => new stdClass(),
+        ];
+
+        yield 'Adding string' => [
+            'argument' => 'str1',
+        ];
+    }
+
+    public function test_list_constructor_throws_an_exception_when_keys_are_specified(): void
+    {
+        $this->expectExceptionObject(ListException::keysNotAllowed());
+
+        new MutableIntegerList(['invalid' => 1]);
+    }
+
+    public function test_list_constructor_does_not_throw_any_exception_when_keys_are_not_specified(): void
+    {
+        $test = new MutableIntegerList([2]);
+
+        self::assertEquals(2, $test[0]);
+    }
+
+    public function test_list_setter_throws_an_exception_when_key_is_specified(): void
+    {
+        $test = new MutableIntegerList([3]);
+
+        $this->expectExceptionObject(ListException::keysNotAllowed());
+
+        $test['invalid'] = 5;
+    }
+
+    public function test_list_setter_does_not_throw_any_exception_when_key_is_not_specified(): void
+    {
+        $test = new MutableIntegerList([8]);
+
+        $test[] = 13;
+
+        self::assertEquals(13, $test[1]);
+    }
+
+    public function test_list_setter_does_not_throw_any_exception_when_an_element_is_modified_by_key(): void
+    {
+        $test = new MutableIntegerList([21]);
+
+        $test[0] = 34;
+
+        self::assertEquals(34, $test[0]);
+    }
+}

--- a/tests/Unit/Scalars/MutableIntegerMapTest.php
+++ b/tests/Unit/Scalars/MutableIntegerMapTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Scalars;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypedArrays\AbstractTypedArray;
+use TypedArrays\Exceptions\InvalidTypeException;
+use TypedArrays\Exceptions\MapException;
+use TypedArrays\Scalars\MutableIntegerMap;
+
+final class MutableIntegerMapTest extends TestCase
+{
+    public function test_construct(): void
+    {
+        $test = new MutableIntegerMap(['key' => 1]);
+
+        self::assertInstanceOf(MutableIntegerMap::class, $test);
+        self::assertInstanceOf(AbstractTypedArray::class, $test);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputTypeOnInstantiate
+     */
+    public function test_invalid_scalar_input_type_on_instantiate(array $arguments): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        new MutableIntegerMap($arguments);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputTypeOnAdd
+     *
+     * @param mixed $argument
+     */
+    public function test_invalid_scalar_input_type_on_add($argument): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        $test = new MutableIntegerMap([]);
+        $test['invalid'] = $argument;
+    }
+
+    public function providerInvalidScalarInputTypeOnInstantiate(): Generator
+    {
+        yield 'Receiving floats' => [
+            'arguments' => ['key1' => 1.23, 'key2' => 4.56],
+        ];
+
+        yield 'Receiving booleans' => [
+            'arguments' => ['key1' => true, 'key2' => false],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => ['key1' => new stdClass(), 'key2' => new stdClass()],
+        ];
+
+        yield 'Receiving strings' => [
+            'arguments' => ['key1' => 'str1', 'key2' => 'str2'],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => ['key1' => true, 'key2' => 1, 'key3' => 2.3, 'key4' => 'string', 'key5' => new stdClass()],
+        ];
+    }
+
+    public function providerInvalidScalarInputTypeOnAdd(): Generator
+    {
+        yield 'Adding float' => [
+            'argument' => 1.23,
+        ];
+
+        yield 'Adding boolean' => [
+            'argument' => true,
+        ];
+
+        yield 'Adding stdClass' => [
+            'argument' => new stdClass(),
+        ];
+
+        yield 'Adding string' => [
+            'argument' => 'str1',
+        ];
+    }
+
+    public function test_map_constructor_throws_an_exception_when_keys_are_not_specified(): void
+    {
+        $this->expectExceptionObject(MapException::keysRequired());
+
+        new MutableIntegerMap([13]);
+    }
+
+    public function test_map_constructor_does_not_throw_any_exception_when_keys_are_specified(): void
+    {
+        $test = new MutableIntegerMap(['valid' => 3]);
+
+        self::assertSame(3, $test['valid']);
+    }
+
+    public function test_map_constructor_doest_not_throw_any_exception_when_empty_array_given(): void
+    {
+        $test = new MutableIntegerMap([]);
+
+        self::assertEmpty((array) $test);
+    }
+
+    public function test_map_setter_throws_an_exception_when_key_is_not_specified(): void
+    {
+        $test = new MutableIntegerMap(['valid' => 14]);
+
+        $this->expectExceptionObject(MapException::keysRequired());
+
+        $test[] = 15;
+    }
+
+    public function test_map_setter_does_not_throw_any_exception_when_key_is_specified(): void
+    {
+        $test = new MutableIntegerMap(['key' => 92]);
+
+        $test['valid'] = 65;
+
+        self::assertSame(65, $test['valid']);
+    }
+}

--- a/tests/Unit/Scalars/MutableIntegerMapTest.php
+++ b/tests/Unit/Scalars/MutableIntegerMapTest.php
@@ -45,6 +45,45 @@ final class MutableIntegerMapTest extends TestCase
         $test['invalid'] = $argument;
     }
 
+    public function test_map_constructor_throws_an_exception_when_keys_are_not_specified(): void
+    {
+        $this->expectExceptionObject(MapException::keysRequired());
+
+        new MutableIntegerMap([13]);
+    }
+
+    public function test_map_constructor_does_not_throw_any_exception_when_keys_are_specified(): void
+    {
+        $test = new MutableIntegerMap(['valid' => 3]);
+
+        self::assertSame(3, $test['valid']);
+    }
+
+    public function test_map_constructor_doest_not_throw_any_exception_when_empty_array_given(): void
+    {
+        $test = new MutableIntegerMap([]);
+
+        self::assertEmpty((array) $test);
+    }
+
+    public function test_map_setter_throws_an_exception_when_key_is_not_specified(): void
+    {
+        $test = new MutableIntegerMap(['valid' => 14]);
+
+        $this->expectExceptionObject(MapException::keysRequired());
+
+        $test[] = 15;
+    }
+
+    public function test_map_setter_does_not_throw_any_exception_when_key_is_specified(): void
+    {
+        $test = new MutableIntegerMap(['key' => 92]);
+
+        $test['valid'] = 65;
+
+        self::assertSame(65, $test['valid']);
+    }
+
     public function providerInvalidScalarInputTypeOnInstantiate(): Generator
     {
         yield 'Receiving floats' => [
@@ -85,44 +124,5 @@ final class MutableIntegerMapTest extends TestCase
         yield 'Adding string' => [
             'argument' => 'str1',
         ];
-    }
-
-    public function test_map_constructor_throws_an_exception_when_keys_are_not_specified(): void
-    {
-        $this->expectExceptionObject(MapException::keysRequired());
-
-        new MutableIntegerMap([13]);
-    }
-
-    public function test_map_constructor_does_not_throw_any_exception_when_keys_are_specified(): void
-    {
-        $test = new MutableIntegerMap(['valid' => 3]);
-
-        self::assertSame(3, $test['valid']);
-    }
-
-    public function test_map_constructor_doest_not_throw_any_exception_when_empty_array_given(): void
-    {
-        $test = new MutableIntegerMap([]);
-
-        self::assertEmpty((array) $test);
-    }
-
-    public function test_map_setter_throws_an_exception_when_key_is_not_specified(): void
-    {
-        $test = new MutableIntegerMap(['valid' => 14]);
-
-        $this->expectExceptionObject(MapException::keysRequired());
-
-        $test[] = 15;
-    }
-
-    public function test_map_setter_does_not_throw_any_exception_when_key_is_specified(): void
-    {
-        $test = new MutableIntegerMap(['key' => 92]);
-
-        $test['valid'] = 65;
-
-        self::assertSame(65, $test['valid']);
     }
 }

--- a/tests/Unit/Scalars/MutableStringArrayTest.php
+++ b/tests/Unit/Scalars/MutableStringArrayTest.php
@@ -9,15 +9,15 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 use TypedArrays\AbstractTypedArray;
 use TypedArrays\Exceptions\InvalidTypeException;
-use TypedArrays\Scalars\TypedArrayInteger;
+use TypedArrays\Scalars\MutableStringArray;
 
-final class TypedArrayIntegerTest extends TestCase
+final class MutableStringArrayTest extends TestCase
 {
     public function testConstruct(): void
     {
-        $test = new TypedArrayInteger([1]);
+        $test = new MutableStringArray(['test']);
 
-        self::assertInstanceOf(TypedArrayInteger::class, $test);
+        self::assertInstanceOf(MutableStringArray::class, $test);
         self::assertInstanceOf(AbstractTypedArray::class, $test);
     }
 
@@ -28,7 +28,7 @@ final class TypedArrayIntegerTest extends TestCase
     {
         $this->expectException(InvalidTypeException::class);
 
-        new TypedArrayInteger($arguments);
+        new MutableStringArray($arguments);
     }
 
     /**
@@ -40,12 +40,16 @@ final class TypedArrayIntegerTest extends TestCase
     {
         $this->expectException(InvalidTypeException::class);
 
-        $test = new TypedArrayInteger([]);
+        $test = new MutableStringArray([]);
         $test[] = $argument;
     }
 
     public function providerInvalidScalarInputTypeOnInstantiate(): Generator
     {
+        yield 'Receiving integers' => [
+            'arguments' => [1, 2],
+        ];
+
         yield 'Receiving floats' => [
             'arguments' => [1.23, 4.56],
         ];
@@ -58,10 +62,6 @@ final class TypedArrayIntegerTest extends TestCase
             'arguments' => [new stdClass(), new stdClass()],
         ];
 
-        yield 'Receiving strings' => [
-            'arguments' => ['str1', 'str2'],
-        ];
-
         yield 'Receiving a mix of all scalars' => [
             'arguments' => [true, 1, 2.3, 'string', new stdClass()],
         ];
@@ -69,6 +69,10 @@ final class TypedArrayIntegerTest extends TestCase
 
     public function providerInvalidScalarInputTypeOnAdd(): Generator
     {
+        yield 'Adding integer' => [
+            'argument' => 1,
+        ];
+
         yield 'Adding float' => [
             'argument' => 1.23,
         ];
@@ -79,10 +83,6 @@ final class TypedArrayIntegerTest extends TestCase
 
         yield 'Adding stdClass' => [
             'argument' => new stdClass(),
-        ];
-
-        yield 'Adding string' => [
-            'argument' => 'str1',
         ];
     }
 }

--- a/tests/Unit/Scalars/MutableStringArrayTest.php
+++ b/tests/Unit/Scalars/MutableStringArrayTest.php
@@ -13,7 +13,7 @@ use TypedArrays\Scalars\MutableStringArray;
 
 final class MutableStringArrayTest extends TestCase
 {
-    public function testConstruct(): void
+    public function test_construct(): void
     {
         $test = new MutableStringArray(['test']);
 
@@ -24,7 +24,7 @@ final class MutableStringArrayTest extends TestCase
     /**
      * @dataProvider providerInvalidScalarInputTypeOnInstantiate
      */
-    public function testInvalidScalarInputTypeOnInstantiate(array $arguments): void
+    public function test_invalid_scalar_input_type_on_instantiate(array $arguments): void
     {
         $this->expectException(InvalidTypeException::class);
 
@@ -36,7 +36,7 @@ final class MutableStringArrayTest extends TestCase
      *
      * @param mixed $argument
      */
-    public function testInvalidScalarInputTypeOnAdd($argument): void
+    public function test_invalid_scalar_input_type_on_add($argument): void
     {
         $this->expectException(InvalidTypeException::class);
 

--- a/tests/Unit/Scalars/MutableStringListTest.php
+++ b/tests/Unit/Scalars/MutableStringListTest.php
@@ -98,7 +98,7 @@ final class MutableStringListTest extends TestCase
     {
         $test = new MutableStringList(['test']);
 
-        self::assertEquals('test', $test[0]);
+        self::assertSame('test', $test[0]);
     }
 
     public function test_list_setter_throws_an_exception_when_key_is_specified(): void
@@ -116,7 +116,7 @@ final class MutableStringListTest extends TestCase
 
         $test[] = 'valid';
 
-        self::assertEquals('valid', $test[1]);
+        self::assertSame('valid', $test[1]);
     }
 
     public function test_list_setter_does_not_throw_any_exception_when_an_element_is_modified_by_key(): void
@@ -125,6 +125,6 @@ final class MutableStringListTest extends TestCase
 
         $test[0] = 'modified';
 
-        self::assertEquals('modified', $test[0]);
+        self::assertSame('modified', $test[0]);
     }
 }

--- a/tests/Unit/Scalars/MutableStringListTest.php
+++ b/tests/Unit/Scalars/MutableStringListTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Scalars;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypedArrays\AbstractTypedArray;
+use TypedArrays\Exceptions\InvalidTypeException;
+use TypedArrays\Exceptions\ListException;
+use TypedArrays\Scalars\MutableStringList;
+
+final class MutableStringListTest extends TestCase
+{
+    public function test_construct(): void
+    {
+        $test = new MutableStringList(['test']);
+
+        self::assertInstanceOf(MutableStringList::class, $test);
+        self::assertInstanceOf(AbstractTypedArray::class, $test);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputTypeOnInstantiate
+     */
+    public function test_invalid_scalar_input_type_on_instantiate(array $arguments): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        new MutableStringList($arguments);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputTypeOnAdd
+     *
+     * @param mixed $argument
+     */
+    public function test_invalid_scalar_input_type_on_add($argument): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        $test = new MutableStringList([]);
+        $test[] = $argument;
+    }
+
+    public function providerInvalidScalarInputTypeOnInstantiate(): Generator
+    {
+        yield 'Receiving integers' => [
+            'arguments' => [1, 2],
+        ];
+
+        yield 'Receiving floats' => [
+            'arguments' => [1.23, 4.56],
+        ];
+
+        yield 'Receiving booleans' => [
+            'arguments' => [true, false],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => [new stdClass(), new stdClass()],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => [true, 1, 2.3, 'string', new stdClass()],
+        ];
+    }
+
+    public function providerInvalidScalarInputTypeOnAdd(): Generator
+    {
+        yield 'Adding integer' => [
+            'argument' => 1,
+        ];
+
+        yield 'Adding float' => [
+            'argument' => 1.23,
+        ];
+
+        yield 'Adding boolean' => [
+            'argument' => true,
+        ];
+
+        yield 'Adding stdClass' => [
+            'argument' => new stdClass(),
+        ];
+    }
+
+    public function test_list_constructor_throws_an_exception_when_keys_are_specified(): void
+    {
+        $this->expectExceptionObject(ListException::keysNotAllowed());
+
+        new MutableStringList(['invalid' => 'test']);
+    }
+
+    public function test_list_constructor_does_not_throw_any_exception_when_keys_are_not_specified(): void
+    {
+        $test = new MutableStringList(['test']);
+
+        self::assertEquals('test', $test[0]);
+    }
+
+    public function test_list_setter_throws_an_exception_when_key_is_specified(): void
+    {
+        $test = new MutableStringList(['valid']);
+
+        $this->expectExceptionObject(ListException::keysNotAllowed());
+
+        $test['invalid'] = 'test';
+    }
+
+    public function test_list_setter_does_not_throw_any_exception_when_key_is_not_specified(): void
+    {
+        $test = new MutableStringList(['test']);
+
+        $test[] = 'valid';
+
+        self::assertEquals('valid', $test[1]);
+    }
+
+    public function test_list_setter_does_not_throw_any_exception_when_an_element_is_modified_by_key(): void
+    {
+        $test = new MutableStringList(['unmodified']);
+
+        $test[0] = 'modified';
+
+        self::assertEquals('modified', $test[0]);
+    }
+}

--- a/tests/Unit/Scalars/MutableStringListTest.php
+++ b/tests/Unit/Scalars/MutableStringListTest.php
@@ -45,6 +45,47 @@ final class MutableStringListTest extends TestCase
         $test[] = $argument;
     }
 
+    public function test_list_constructor_throws_an_exception_when_keys_are_specified(): void
+    {
+        $this->expectExceptionObject(ListException::keysNotAllowed());
+
+        new MutableStringList(['invalid' => 'test']);
+    }
+
+    public function test_list_constructor_does_not_throw_any_exception_when_keys_are_not_specified(): void
+    {
+        $test = new MutableStringList(['test']);
+
+        self::assertSame('test', $test[0]);
+    }
+
+    public function test_list_setter_throws_an_exception_when_key_is_specified(): void
+    {
+        $test = new MutableStringList(['valid']);
+
+        $this->expectExceptionObject(ListException::keysNotAllowed());
+
+        $test['invalid'] = 'test';
+    }
+
+    public function test_list_setter_does_not_throw_any_exception_when_key_is_not_specified(): void
+    {
+        $test = new MutableStringList(['test']);
+
+        $test[] = 'valid';
+
+        self::assertSame('valid', $test[1]);
+    }
+
+    public function test_list_setter_does_not_throw_any_exception_when_an_element_is_modified_by_key(): void
+    {
+        $test = new MutableStringList(['unmodified']);
+
+        $test[0] = 'modified';
+
+        self::assertSame('modified', $test[0]);
+    }
+
     public function providerInvalidScalarInputTypeOnInstantiate(): Generator
     {
         yield 'Receiving integers' => [
@@ -85,46 +126,5 @@ final class MutableStringListTest extends TestCase
         yield 'Adding stdClass' => [
             'argument' => new stdClass(),
         ];
-    }
-
-    public function test_list_constructor_throws_an_exception_when_keys_are_specified(): void
-    {
-        $this->expectExceptionObject(ListException::keysNotAllowed());
-
-        new MutableStringList(['invalid' => 'test']);
-    }
-
-    public function test_list_constructor_does_not_throw_any_exception_when_keys_are_not_specified(): void
-    {
-        $test = new MutableStringList(['test']);
-
-        self::assertSame('test', $test[0]);
-    }
-
-    public function test_list_setter_throws_an_exception_when_key_is_specified(): void
-    {
-        $test = new MutableStringList(['valid']);
-
-        $this->expectExceptionObject(ListException::keysNotAllowed());
-
-        $test['invalid'] = 'test';
-    }
-
-    public function test_list_setter_does_not_throw_any_exception_when_key_is_not_specified(): void
-    {
-        $test = new MutableStringList(['test']);
-
-        $test[] = 'valid';
-
-        self::assertSame('valid', $test[1]);
-    }
-
-    public function test_list_setter_does_not_throw_any_exception_when_an_element_is_modified_by_key(): void
-    {
-        $test = new MutableStringList(['unmodified']);
-
-        $test[0] = 'modified';
-
-        self::assertSame('modified', $test[0]);
     }
 }

--- a/tests/Unit/Scalars/MutableStringMapTest.php
+++ b/tests/Unit/Scalars/MutableStringMapTest.php
@@ -45,6 +45,45 @@ final class MutableStringMapTest extends TestCase
         $test['invalid'] = $argument;
     }
 
+    public function test_map_constructor_throws_an_exception_when_keys_are_not_specified(): void
+    {
+        $this->expectExceptionObject(MapException::keysRequired());
+
+        new MutableStringMap(['invalid']);
+    }
+
+    public function test_map_constructor_does_not_throw_any_exception_when_keys_are_specified(): void
+    {
+        $test = new MutableStringMap(['valid' => 'test']);
+
+        self::assertSame('test', $test['valid']);
+    }
+
+    public function test_map_constructor_doest_not_throw_any_exception_when_empty_array_given(): void
+    {
+        $test = new MutableStringMap([]);
+
+        self::assertEmpty((array) $test);
+    }
+
+    public function test_map_setter_throws_an_exception_when_key_is_not_specified(): void
+    {
+        $test = new MutableStringMap(['valid' => 'test']);
+
+        $this->expectExceptionObject(MapException::keysRequired());
+
+        $test[] = 'invalid';
+    }
+
+    public function test_map_setter_does_not_throw_any_exception_when_key_is_specified(): void
+    {
+        $test = new MutableStringMap(['key' => 'test']);
+
+        $test['valid'] = 'expected';
+
+        self::assertSame('expected', $test['valid']);
+    }
+
     public function providerInvalidScalarInputTypeOnInstantiate(): Generator
     {
         yield 'Receiving integers' => [
@@ -85,44 +124,5 @@ final class MutableStringMapTest extends TestCase
         yield 'Adding stdClass' => [
             'argument' => new stdClass(),
         ];
-    }
-
-    public function test_map_constructor_throws_an_exception_when_keys_are_not_specified(): void
-    {
-        $this->expectExceptionObject(MapException::keysRequired());
-
-        new MutableStringMap(['invalid']);
-    }
-
-    public function test_map_constructor_does_not_throw_any_exception_when_keys_are_specified(): void
-    {
-        $test = new MutableStringMap(['valid' => 'test']);
-
-        self::assertSame('test', $test['valid']);
-    }
-
-    public function test_map_constructor_doest_not_throw_any_exception_when_empty_array_given(): void
-    {
-        $test = new MutableStringMap([]);
-
-        self::assertEmpty((array) $test);
-    }
-
-    public function test_map_setter_throws_an_exception_when_key_is_not_specified(): void
-    {
-        $test = new MutableStringMap(['valid' => 'test']);
-
-        $this->expectExceptionObject(MapException::keysRequired());
-
-        $test[] = 'invalid';
-    }
-
-    public function test_map_setter_does_not_throw_any_exception_when_key_is_specified(): void
-    {
-        $test = new MutableStringMap(['key' => 'test']);
-
-        $test['valid'] = 'expected';
-
-        self::assertSame('expected', $test['valid']);
     }
 }

--- a/tests/Unit/Scalars/MutableStringMapTest.php
+++ b/tests/Unit/Scalars/MutableStringMapTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypedArraysTest\Unit\Scalars;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TypedArrays\AbstractTypedArray;
+use TypedArrays\Exceptions\InvalidTypeException;
+use TypedArrays\Exceptions\MapException;
+use TypedArrays\Scalars\MutableStringMap;
+
+final class MutableStringMapTest extends TestCase
+{
+    public function test_construct(): void
+    {
+        $test = new MutableStringMap(['key' => 'test']);
+
+        self::assertInstanceOf(MutableStringMap::class, $test);
+        self::assertInstanceOf(AbstractTypedArray::class, $test);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputTypeOnInstantiate
+     */
+    public function test_invalid_scalar_input_type_on_instantiate(array $arguments): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        new MutableStringMap($arguments);
+    }
+
+    /**
+     * @dataProvider providerInvalidScalarInputTypeOnAdd
+     *
+     * @param mixed $argument
+     */
+    public function test_invalid_scalar_input_type_on_add($argument): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        $test = new MutableStringMap([]);
+        $test['invalid'] = $argument;
+    }
+
+    public function providerInvalidScalarInputTypeOnInstantiate(): Generator
+    {
+        yield 'Receiving integers' => [
+            'arguments' => ['key1' => 1, 'key2' => 2],
+        ];
+
+        yield 'Receiving floats' => [
+            'arguments' => ['key1' => 1.23, 'key2' => 4.56],
+        ];
+
+        yield 'Receiving booleans' => [
+            'arguments' => ['key1' => true, 'key2' => false],
+        ];
+
+        yield 'Receiving stdClasses' => [
+            'arguments' => ['key1' => new stdClass(), 'key2' => new stdClass()],
+        ];
+
+        yield 'Receiving a mix of all scalars' => [
+            'arguments' => ['key1' => true, 'key2' => 1, 'key3' => 2.3, 'key4' => 'string', 'key5' => new stdClass()],
+        ];
+    }
+
+    public function providerInvalidScalarInputTypeOnAdd(): Generator
+    {
+        yield 'Adding integer' => [
+            'argument' => 1,
+        ];
+
+        yield 'Adding float' => [
+            'argument' => 1.23,
+        ];
+
+        yield 'Adding boolean' => [
+            'argument' => true,
+        ];
+
+        yield 'Adding stdClass' => [
+            'argument' => new stdClass(),
+        ];
+    }
+
+    public function test_map_constructor_throws_an_exception_when_keys_are_not_specified(): void
+    {
+        $this->expectExceptionObject(MapException::keysRequired());
+
+        new MutableStringMap(['invalid']);
+    }
+
+    public function test_map_constructor_does_not_throw_any_exception_when_keys_are_specified(): void
+    {
+        $test = new MutableStringMap(['valid' => 'test']);
+
+        self::assertSame('test', $test['valid']);
+    }
+
+    public function test_map_constructor_doest_not_throw_any_exception_when_empty_array_given(): void
+    {
+        $test = new MutableStringMap([]);
+
+        self::assertEmpty((array) $test);
+    }
+
+    public function test_map_setter_throws_an_exception_when_key_is_not_specified(): void
+    {
+        $test = new MutableStringMap(['valid' => 'test']);
+
+        $this->expectExceptionObject(MapException::keysRequired());
+
+        $test[] = 'invalid';
+    }
+
+    public function test_map_setter_does_not_throw_any_exception_when_key_is_specified(): void
+    {
+        $test = new MutableStringMap(['key' => 'test']);
+
+        $test['valid'] = 'expected';
+
+        self::assertSame('expected', $test['valid']);
+    }
+}

--- a/tests/Unit/TypedArrayTest.php
+++ b/tests/Unit/TypedArrayTest.php
@@ -13,7 +13,7 @@ use TypedArraysTest\Unit\Fixtures\TypedArraySimpleObjects;
 
 final class TypedArrayTest extends TestCase
 {
-    public function testValidEnforcementTypes(): void
+    public function test_valid_enforcement_types(): void
     {
         $validScalar = new MutableStringArray();
         self::assertInstanceOf(AbstractTypedArray::class, $validScalar);
@@ -22,7 +22,7 @@ final class TypedArrayTest extends TestCase
         self::assertInstanceOf(AbstractTypedArray::class, $validClass);
     }
 
-    public function testKeysArePreserved(): void
+    public function test_keys_are_preserved(): void
     {
         $input = [
             'key1' => 'value1',
@@ -34,7 +34,7 @@ final class TypedArrayTest extends TestCase
         self::assertEquals(['key1', 'key2'], array_keys($test));
     }
 
-    public function testInvalidScalarEnforcementType(): void
+    public function test_invalid_scalar_enforcement_type(): void
     {
         $this->expectException(InvalidSetupException::class);
 
@@ -46,7 +46,7 @@ final class TypedArrayTest extends TestCase
         };
     }
 
-    public function testInvalidClassEnforcementType(): void
+    public function test_invalid_class_enforcement_type(): void
     {
         $this->expectException(InvalidSetupException::class);
 
@@ -58,7 +58,7 @@ final class TypedArrayTest extends TestCase
         };
     }
 
-    public function testValidInputTypes(): void
+    public function test_valid_input_types(): void
     {
         $scalars = new MutableStringArray(['test', 'test-again']);
         self::assertInstanceOf(AbstractTypedArray::class, $scalars);
@@ -67,7 +67,7 @@ final class TypedArrayTest extends TestCase
         self::assertInstanceOf(AbstractTypedArray::class, $classes);
     }
 
-    public function testCanUseAsArray(): void
+    public function test_can_use_as_array(): void
     {
         $test = new MutableStringArray(['test1', 'test2']);
 

--- a/tests/Unit/TypedArrayTest.php
+++ b/tests/Unit/TypedArrayTest.php
@@ -7,7 +7,7 @@ namespace TypedArraysTest\Unit;
 use PHPUnit\Framework\TestCase;
 use TypedArrays\AbstractTypedArray;
 use TypedArrays\Exceptions\InvalidSetupException;
-use TypedArrays\Scalars\TypedArrayString;
+use TypedArrays\Scalars\MutableStringArray;
 use TypedArraysTest\Unit\Fixtures\SimpleObject;
 use TypedArraysTest\Unit\Fixtures\TypedArraySimpleObjects;
 
@@ -15,7 +15,7 @@ final class TypedArrayTest extends TestCase
 {
     public function testValidEnforcementTypes(): void
     {
-        $validScalar = new TypedArrayString();
+        $validScalar = new MutableStringArray();
         self::assertInstanceOf(AbstractTypedArray::class, $validScalar);
 
         $validClass = new TypedArraySimpleObjects();
@@ -29,7 +29,7 @@ final class TypedArrayTest extends TestCase
             'key2' => 'value2',
         ];
 
-        $test = (array) new TypedArrayString($input);
+        $test = (array) new MutableStringArray($input);
 
         self::assertEquals(['key1', 'key2'], array_keys($test));
     }
@@ -60,7 +60,7 @@ final class TypedArrayTest extends TestCase
 
     public function testValidInputTypes(): void
     {
-        $scalars = new TypedArrayString(['test', 'test-again']);
+        $scalars = new MutableStringArray(['test', 'test-again']);
         self::assertInstanceOf(AbstractTypedArray::class, $scalars);
 
         $classes = new TypedArraySimpleObjects([new SimpleObject(), new SimpleObject()]);
@@ -69,7 +69,7 @@ final class TypedArrayTest extends TestCase
 
     public function testCanUseAsArray(): void
     {
-        $test = new TypedArrayString(['test1', 'test2']);
+        $test = new MutableStringArray(['test1', 'test2']);
 
         self::assertEquals('test1', $test[0]);
         self::assertEquals('test2', $test[1]);

--- a/tests/Unit/TypedArrayTest.php
+++ b/tests/Unit/TypedArrayTest.php
@@ -31,7 +31,7 @@ final class TypedArrayTest extends TestCase
 
         $test = (array) new MutableStringArray($input);
 
-        self::assertEquals(['key1', 'key2'], array_keys($test));
+        self::assertSame(['key1', 'key2'], array_keys($test));
     }
 
     public function test_invalid_scalar_enforcement_type(): void
@@ -71,8 +71,8 @@ final class TypedArrayTest extends TestCase
     {
         $test = new MutableStringArray(['test1', 'test2']);
 
-        self::assertEquals('test1', $test[0]);
-        self::assertEquals('test2', $test[1]);
+        self::assertSame('test1', $test[0]);
+        self::assertSame('test2', $test[1]);
         self::assertTrue(isset($test[0]));
         self::assertFalse(isset($test[100]));
 


### PR DESCRIPTION
## 📚 Description

Created the 24 types of predefined collections of scalars included by default with the library

## 🔖 Changes

- Renamed existing scalars by Mutable[type]Array
- Added Immutable[type]Array classes
- Added Mutable[type]List classes
- Added Immutable[type]List classes
- Added Mutable[type]Map classes
- Added Immutable[type]Map classes
- Change test names to snake case to improve readability
- Made tests more stricts on type checking
- 🐞 Fixed a bug where empty maps could not be created
